### PR TITLE
RHCLOUD-15264:  Payload Tracker can consume from Kafka

### DIFF
--- a/cmd/payload-tracker-consumer/main.go
+++ b/cmd/payload-tracker-consumer/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/redhatinsights/payload-tracker-go/internal/config"
+	"github.com/redhatinsights/payload-tracker-go/internal/db"
 	"github.com/redhatinsights/payload-tracker-go/internal/kafka"
 	"github.com/redhatinsights/payload-tracker-go/internal/logging"
 )
@@ -14,6 +15,9 @@ func main() {
 	cfg := config.Get()
 	ctx := context.Background()
 
+	logging.Log.Info("Setting up DB")
+	db.DbConnect(cfg)
+
 	logging.Log.Info("Starting a new kafka consumer...")
 	logging.Log.Info("Config for Consumer: ", cfg)
 
@@ -23,7 +27,5 @@ func main() {
 		logging.Log.Fatal("ERROR! ", err)
 	}
 
-	// TODO: Add Handler in here
-
-	kafka.NewConsumerEventLoop(ctx, consumer) // TODO: add in handler
+	kafka.NewConsumerEventLoop(ctx, cfg, consumer, db.DB)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhatinsights/payload-tracker-go
 go 1.14
 
 require (
+	github.com/atombender/go-jsonschema v0.9.0 // indirect
 	github.com/aws/aws-sdk-go v1.40.13
 	github.com/confluentinc/confluent-kafka-go v1.7.0
 	github.com/go-chi/chi/v5 v5.0.3
@@ -13,6 +14,8 @@ require (
 	github.com/qri-io/jsonschema v0.2.1
 	github.com/redhatinsights/app-common-go v1.5.1
 	github.com/redhatinsights/platform-go-middlewares v0.9.0
+	github.com/redis-go/redcon v0.2.0 // indirect
+	github.com/redis-go/redis v0.0.0-20190129163758-e7bb29b08926
 	github.com/segmentio/kafka-go v0.4.17
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -416,11 +417,13 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
@@ -671,6 +674,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -961,6 +965,7 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -57,6 +58,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/atombender/go-jsonschema v0.9.0 h1:p401YAKXnAURMwNXUB7oJMn6KDAS34IauXnoFk7iPfk=
+github.com/atombender/go-jsonschema v0.9.0/go.mod h1:ev1S/jfIbe8uIdBSPPVWB0Pj7NuHTe+JkM2Gw+JaaD8=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -99,6 +102,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -134,6 +139,16 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-redis/cache v1.0.1 h1:FjgFUi7srQ7fNVBWvvm7SeOOfzNh0IfRoK6Pnxubhds=
+github.com/go-redis/cache v6.4.0+incompatible h1:ZaeoZofvBZmMr8ZKxzFDmkoRTSp8sxHdJlB3e3T6GDA=
+github.com/go-redis/cache/v8 v8.4.1 h1:jq0fw7hcUJzsoS9qPYjXzcAT/rm19TRMB1vEMG3m950=
+github.com/go-redis/cache/v8 v8.4.1/go.mod h1:iyYQNUxMsz6cPfTX3h4sT4lUmDXV0mDuEyeAn2o1btI=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v8 v8.4.4 h1:fGqgxCTR1sydaKI00oQf3OmkU/DIe/I/fYXvGklCIuc=
+github.com/go-redis/redis/v8 v8.4.4/go.mod h1:nA0bQuF0i5JFx4Ta9RZxGKXFrQ8cRWntra97f0196iY=
+github.com/go-redis/redis/v8 v8.11.2 h1:WqlSpAwz8mxDSMCvbyz1Mkiqe0LE5OY4j3lgkvu1Ts0=
+github.com/go-redis/redis/v8 v8.11.2/go.mod h1:DLomh7y2e3ggQXQLd1YgmvIfecPJoFl7WU5SOQ/r06M=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
@@ -178,6 +193,7 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -191,6 +207,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -208,6 +225,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -251,6 +269,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
@@ -328,6 +347,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+OykW8=
+github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -365,6 +386,8 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -385,24 +408,19 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
@@ -463,6 +481,8 @@ github.com/redhatinsights/app-common-go v1.5.1 h1:M0HuhnP6oR1CzJsCjxlnxcFiEVeg5f
 github.com/redhatinsights/app-common-go v1.5.1/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.9.0 h1:gDKP4XI+ppZdTRfVGJYBENdMM58hKlbVUzXBaY32F/I=
 github.com/redhatinsights/platform-go-middlewares v0.9.0/go.mod h1:koDaxx4Ht3ZgXqAhfkKFhBy9586kZ3aDm9IAlEs0Oo4=
+github.com/redis-go/redcon v0.2.0/go.mod h1:tRS+pqvUi4CdCDkf+qytjfwToeMHPxBIHWR15HC2ZUo=
+github.com/redis-go/redis v0.0.0-20190129163758-e7bb29b08926/go.mod h1:cplKPsu41XF1ayYjPBI69+rhEbnDv4xS4Im/c28NhwI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -472,6 +492,7 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sanity-io/litter v1.1.0/go.mod h1:CJ0VCw2q4qKU7LaQr3n7UOSHzgEMgcGco7N/SkZQPjw=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/kafka-go v0.4.17/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=
@@ -482,7 +503,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -498,6 +518,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
@@ -650,7 +671,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -746,7 +766,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -812,14 +831,12 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -938,14 +955,12 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,6 @@ type TrackerConfig struct {
 	CloudwatchConfig CloudwatchCfg
 	DatabaseConfig   DatabaseCfg
 	RequestConfig    RequestCfg
-	RedisConfig      RedisCfg
 }
 
 type KafkaCfg struct {
@@ -59,12 +58,6 @@ type RequestCfg struct {
 	ValidateRequestIDLength int
 }
 
-type RedisCfg struct {
-	UseRedis  bool
-	RedisHost string
-	RedisPort int
-}
-
 // Get sets each config option with its defaults
 func Get() *TrackerConfig {
 	options := viper.New()
@@ -91,9 +84,6 @@ func Get() *TrackerConfig {
 	options.SetDefault("validate.request.id", "true")
 	options.SetDefault("validate.request.id.length", 32)
 
-	// redis config
-	options.SetDefault("use.redis", "false")
-
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig
 
@@ -115,9 +105,6 @@ func Get() *TrackerConfig {
 		options.SetDefault("cwRegion", cfg.Logging.Cloudwatch.Region)
 		options.SetDefault("cwAccessKey", cfg.Logging.Cloudwatch.AccessKeyId)
 		options.SetDefault("cwSecretKey", cfg.Logging.Cloudwatch.SecretAccessKey)
-		// redis
-		options.SetDefault("redis.host", cfg.InMemoryDb.Hostname)
-		options.SetDefault("redis.port", cfg.InMemoryDb.Port)
 	} else {
 		options.SetDefault("kafka.bootstrap.servers", "localhost:29092")
 		options.SetDefault("topic.payload.status", "platform.payload-status")
@@ -135,9 +122,6 @@ func Get() *TrackerConfig {
 		options.SetDefault("cwRegion", "us-east-1")
 		options.SetDefault("cwAccessKey", os.Getenv("CW_AWS_ACCESS_KEY_ID"))
 		options.SetDefault("cwSecretKey", os.Getenv("CW_AWS_SECRET_ACCESS_KEY"))
-		// redis
-		options.SetDefault("redis.host", "localhost")
-		options.SetDefault("redis.port", 6379)
 	}
 
 	options.AutomaticEnv()
@@ -174,11 +158,6 @@ func Get() *TrackerConfig {
 		RequestConfig: RequestCfg{
 			ValidateRequestID:       options.GetBool("validate.request.id"),
 			ValidateRequestIDLength: options.GetInt("validate.request.id.length"),
-		},
-		RedisConfig: RedisCfg{
-			UseRedis:  options.GetBool("use.redis"),
-			RedisHost: options.GetString("redis.host"),
-			RedisPort: options.GetInt("redis.port"),
 		},
 	}
 

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -1,5 +1,0 @@
-package handlers
-
-func onMessage() {
-	// TODO: Add Message handler here
-}

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -1,0 +1,172 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gorm.io/gorm"
+
+	"github.com/redhatinsights/payload-tracker-go/internal/config"
+	l "github.com/redhatinsights/payload-tracker-go/internal/logging"
+	models "github.com/redhatinsights/payload-tracker-go/internal/models/db"
+	"github.com/redhatinsights/payload-tracker-go/internal/models/message"
+	"github.com/redhatinsights/payload-tracker-go/internal/queries"
+)
+
+var (
+	tableNames = []string{"service", "source", "status"}
+)
+
+type handler struct {
+	db *gorm.DB
+}
+
+// OnMessage takes in each payload status message and processes it
+func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config.TrackerConfig) {
+	l.Log.Debug("Processing Payload Message ", msg.Value)
+
+	payloadStatus := &message.PayloadStatusMessage{}
+	sanitizedPayloadStatus := &models.PayloadStatuses{}
+
+	if err := json.Unmarshal(msg.Value, payloadStatus); err != nil {
+		// PROBE: Add probe here for error unmarshaling JSON
+		l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)
+		return
+	}
+
+	// Validate RequestID
+	if cfg.RequestConfig.ValidateRequestID {
+		if len(payloadStatus.RequestID) > cfg.RequestConfig.ValidateRequestIDLength {
+			l.Log.Errorf("ERROR: Payload {value} has invalid request_id length.")
+			return
+		}
+	}
+
+	// Sanitize the payload
+	sanitizePayload(payloadStatus)
+
+	// Check if request_id not in Payloads Table and update columns
+	l.Log.Info("Sanitized Payload for DB ", payloadStatus)
+
+	payloadDump, err := getPayload(this.db, payloadStatus.RequestID)
+	if err != nil && err != gorm.ErrRecordNotFound {
+		l.Log.Error("ERROR: Sanitizing payload failed")
+		return
+	}
+
+	if (models.Payloads{}) == payloadDump {
+		payload := createPayload(payloadStatus)
+
+		result, newPayload := queries.CreatePayloadTableEntry(this.db, payload)
+		if result.Error != nil {
+			l.Log.Error("ERROR Payload table entry creation Failed: ", result.Error)
+			return
+		}
+		sanitizedPayloadStatus.PayloadId = newPayload.Id
+	} else {
+		payloadsUpdate := createPayload(payloadStatus)
+
+		result := queries.UpdatePayloadsTable(this.db, payloadsUpdate, payloadDump)
+		if result.Error != nil {
+			l.Log.Error("ERROR Payload table update failed: ", result.Error)
+			return
+		}
+		sanitizedPayloadStatus.PayloadId = payloadDump.Id
+	}
+
+	// Check if service/source/status are in table
+	// this section checks the subsiquent DB tables to see if the service_id, source_id, and status_id exist for the given message
+	l.Log.Debug("Adding Status, Sources, and Services to sanitizedPayload")
+
+	// Status & Service: Always defined in the message
+	existingStatus := queries.GetStatusByName(this.db, payloadStatus.Status)
+	existingService := queries.GetServiceByName(this.db, payloadStatus.Service)
+	if (models.Statuses{}) == existingStatus {
+		statusResult, newStatus := queries.CreateStatusTableEntry(this.db, payloadStatus.Status)
+		if statusResult.Error != nil {
+			l.Log.Error("Error Creating Statuses Table Entry ERROR: ", statusResult.Error)
+			return
+		}
+
+		sanitizedPayloadStatus.Status = newStatus
+	} else {
+		sanitizedPayloadStatus.Status = existingStatus
+	}
+
+	if (models.Services{}) == existingService {
+		serviceResult, newService := queries.CreateServiceTableEntry(this.db, payloadStatus.Service)
+		if serviceResult.Error != nil {
+			l.Log.Error("Error Creating Service Table Entry ERROR: ", serviceResult.Error)
+			return
+		}
+
+		sanitizedPayloadStatus.Service = newService
+	} else {
+		sanitizedPayloadStatus.Service = existingService
+	}
+
+	// Sources
+	if payloadStatus.Source != "" {
+		existingSource := queries.GetSourceByName(this.db, payloadStatus.Source)
+		if (models.Sources{}) == existingSource {
+			result, newSource := queries.CreateSourceTableEntry(this.db, payloadStatus.Source)
+			if result.Error != nil {
+				l.Log.Error("Error Creating Sources Table Entry ERROR: ", result.Error)
+				return
+			}
+
+			sanitizedPayloadStatus.Source = newSource
+		} else {
+			sanitizedPayloadStatus.Source = existingSource
+		}
+	}
+
+	if payloadStatus.StatusMSG != "" {
+		sanitizedPayloadStatus.StatusMsg = payloadStatus.StatusMSG
+	}
+
+	// Insert Date
+	sanitizedPayloadStatus.Date = payloadStatus.Date.Time
+
+	// Insert payload into DB
+	result := queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
+	if result.Error != nil {
+		l.Log.Debug("Failed to insert sanitized PayloadStatus with ERROR: ", result.Error)
+		result = queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
+		if result.Error != nil {
+			l.Log.Debug("Failed to re-insert sanitized PayloadStatus with ERROR: ", result.Error)
+			result = queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
+			if result.Error != nil {
+				l.Log.Error("Failed final attempt to re-insert PayloadStatus with ERROR: ", result.Error)
+			}
+		}
+	}
+}
+
+func sanitizePayload(msg *message.PayloadStatusMessage) {
+	// Set default fields to lowercase
+	msg.Service = strings.ToLower(msg.Service)
+	msg.Status = strings.ToLower(msg.Status)
+	if msg.Source != "" {
+		msg.Source = strings.ToLower((msg.Source))
+	}
+}
+
+func getPayload(db *gorm.DB, request_id string) (results models.Payloads, err error) {
+	return queries.GetPayloadByRequestId(db, request_id)
+}
+
+func createPayload(msg *message.PayloadStatusMessage) (table models.Payloads) {
+	payloadTable := models.Payloads{
+		Id:          msg.PayloadID,
+		RequestId:   msg.RequestID,
+		Account:     msg.Account,
+		SystemId:    msg.SystemID,
+		CreatedAt:   msg.Date.Time,
+		InventoryId: msg.InventoryID,
+	}
+
+	return payloadTable
+}

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -1,7 +1,5 @@
-package handlers
+package kafka
 
-import (
 // TODO: Add imports here
-)
 
 // TODO: Add Tests here

--- a/internal/migration/main.go
+++ b/internal/migration/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/redhatinsights/payload-tracker-go/internal/config"
 	"github.com/redhatinsights/payload-tracker-go/internal/db"
 	"github.com/redhatinsights/payload-tracker-go/internal/logging"
-	"github.com/redhatinsights/payload-tracker-go/internal/models"
+	models "github.com/redhatinsights/payload-tracker-go/internal/models/db"
 )
 
 func main() {

--- a/internal/models/db/models.go
+++ b/internal/models/db/models.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"time"
+)
+
+type PayloadStatuses struct {
+	ID        uint  `gorm:"primaryKey;not null;autoIncrement"`
+	PayloadId uint  `gorm:"not null"`
+	ServiceId int32 `gorm:"not null"`
+	SourceId  int32
+	StatusId  int32     `gorm:"not null"`
+	StatusMsg string    `gorm:"type:varchar"`
+	Date      time.Time `gorm:"primaryKey;not null"`
+	CreatedAt time.Time `gorm:"not null"`
+	Payload   Payloads
+	Service   Services
+	Source    Sources
+	Status    Statuses
+}
+
+type Payloads struct {
+	Id          uint      `gorm:"primaryKey;not null;autoIncrement"`
+	RequestId   string    `json:"request_id" gorm:"not null;type:varchar"`
+	Account     string    `json:"account" gorm:"type:varchar"`
+	InventoryId string    `json:"inventory_id" gorm:"type:varchar"`
+	SystemId    string    `json:"system_id" gorm:"type:varchar"`
+	CreatedAt   time.Time `gorm:"not null"`
+}
+
+type Services struct {
+	Id   int32  `gorm:"primaryKey;not null;autoIncrement"`
+	Name string `gorm:"not null;type:varchar"`
+}
+
+type Sources struct {
+	Id   int32  `gorm:"primaryKey;not null;autoIncrement"`
+	Name string `gorm:"not null;type:varchar"`
+}
+
+type Statuses struct {
+	Id   int32  `gorm:"primaryKey;not null;autoIncrement"`
+	Name string `gorm:"not null;type:varchar"`
+}

--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	l "github.com/redhatinsights/payload-tracker-go/internal/logging"
+)
+
+var (
+	dateFormat = time.RFC3339
+)
+
+// PayloadStatusMessage it the definition of the Payload Message Status kafka message
+type PayloadStatusMessage struct {
+	Service     string       `json:"service"`
+	Source      string       `json:"source,omitempty"`
+	Account     string       `json:"account,omitempty"`
+	RequestID   string       `json:"request_id"`
+	InventoryID string       `json:"inventory_id,omitempty"`
+	SystemID    string       `json:"system_id,omitempty"`
+	Status      string       `json:"status"`
+	StatusMSG   string       `json:"status_msg,omitempty"`
+	PayloadID   uint         `json:"payload_id,omitempty"`
+	Date        FormatedTime `json:"date"`
+}
+
+type FormatedTime struct {
+	time.Time
+}
+
+func (t *FormatedTime) UnmarshalJSON(b []byte) error {
+	var date string
+	err := json.Unmarshal(b, &date)
+	if err != nil {
+		l.Log.Error("ERROR: Unmarshaling time: ", err)
+		return err
+	}
+
+	date = strings.Join(strings.Fields(date), "T") + "Z"
+
+	t.Time, err = time.Parse(dateFormat, date)
+	if err != nil {
+		l.Log.Error("ERROR: Parsing date into new format: ", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/queries/queries.go
+++ b/internal/queries/queries.go
@@ -1,0 +1,82 @@
+package queries
+
+import (
+	models "github.com/redhatinsights/payload-tracker-go/internal/models/db"
+	"gorm.io/gorm"
+)
+
+const (
+	StatusColumns = "payload_id, status_id, service_id, source_id, date, inventory_id, system_id, account"
+	PayloadJoins  = "left join Payloads on Payloads.id = PayloadStatuses.payload_id"
+)
+
+var (
+	services []models.Services
+	statuses []models.Statuses
+	sources  []models.Sources
+)
+
+func GetServiceByName(db *gorm.DB, service_id string) models.Services {
+	var service models.Services
+	db.Where("name = ?", service_id).First(&service)
+	return service
+}
+
+func GetStatusByName(db *gorm.DB, status_id string) models.Statuses {
+	var status models.Statuses
+	db.Where("name = ?", status_id).First(&status)
+	return status
+}
+
+func GetSourceByName(db *gorm.DB, source_id string) models.Sources {
+	var source models.Sources
+	db.Where("name = ?", source_id).First(&source)
+	return source
+}
+
+func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloads, err error) {
+	var payload models.Payloads
+	if results := db.Where("request_id = ?", request_id).First(&payload); results.Error != nil {
+		return payload, results.Error
+	}
+
+	return payload, nil
+}
+
+func UpdatePayloadsTable(db *gorm.DB, updates models.Payloads, payloads models.Payloads) (tx *gorm.DB) {
+	return db.Model(&payloads).Omit("request_id", "Id").Updates(updates)
+}
+
+func CreatePayloadTableEntry(db *gorm.DB, newPayload models.Payloads) (result *gorm.DB, payload models.Payloads) {
+	results := db.Create(&newPayload)
+
+	return results, newPayload
+}
+
+func CreateStatusTableEntry(db *gorm.DB, name string) (result *gorm.DB, status models.Statuses) {
+	newStatus := models.Statuses{Name: name}
+	results := db.Create(&newStatus)
+
+	return results, newStatus
+}
+
+func CreateSourceTableEntry(db *gorm.DB, name string) (result *gorm.DB, source models.Sources) {
+	newSource := models.Sources{Name: name}
+	results := db.Create(&newSource)
+
+	return results, newSource
+}
+
+func CreateServiceTableEntry(db *gorm.DB, name string) (result *gorm.DB, service models.Services) {
+	newService := models.Services{Name: name}
+	results := db.Create(&newService)
+
+	return results, newService
+}
+
+func InsertPayloadStatus(db *gorm.DB, payloadStatus *models.PayloadStatuses) (tx *gorm.DB) {
+	if (models.Sources{}) == payloadStatus.Source {
+		return db.Omit("source_id").Create(&payloadStatus)
+	}
+	return db.Create(&payloadStatus)
+}

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -1,1 +1,0 @@
-package kafka

--- a/tools/db-seeder/main.go
+++ b/tools/db-seeder/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redhatinsights/payload-tracker-go/internal/config"
 	"github.com/redhatinsights/payload-tracker-go/internal/db"
 	l "github.com/redhatinsights/payload-tracker-go/internal/logging"
-	"github.com/redhatinsights/payload-tracker-go/internal/models"
+	models "github.com/redhatinsights/payload-tracker-go/internal/models/db"
 )
 
 type PayloadStatusJson struct {


### PR DESCRIPTION
Adds the handler logic that allows the payload-tracker-go service to consume from the kafka topic platform.payload-status.  This logic takes in the "Payload Status" message and populates / updates the corresponding tables with the relevant and included data.  Just like the old implementation there are a couple fields that are required in the PayloadStatusMessage
Service, Request_id, Status, and date

These will always be in the Payload Status Message and will error out if not available.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-15264