### PR TITLE
[fix] timestamp bug

### DIFF
--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -39,6 +39,11 @@ func (t *FormatedTime) UnmarshalJSON(b []byte) error {
 	}
 
 	date = strings.Join(strings.Fields(date), "T")
+	
+	// Add a Z to the end of the timestamp if it doesn't exist
+	if !strings.HasSuffix(date, "Z") {
+		date = date + "Z"
+	}
 
 	t.Time, err = time.Parse(dateFormat, date)
 	if err != nil {


### PR DESCRIPTION
We need the Z in the date string in some messages, while others provide
it already. This fix makes sure that we only add it if it's missing,
otherwise we blow up on that message

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>