### PR TITLE
[task] stop unmarshaling payload_id from kafka

### DIFF
--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -22,7 +22,7 @@ type PayloadStatusMessage struct {
 	SystemID    string       `json:"system_id,omitempty"`
 	Status      string       `json:"status"`
 	StatusMSG   string       `json:"status_msg,omitempty"`
-	PayloadID   uint         `json:"payload_id,omitempty"`
+	PayloadID   uint         
 	Date        FormatedTime `json:"date"`
 }
 


### PR DESCRIPTION
Payload ID is a legacy key in the kafka message. We used it before we
switched to calling it request_id. We can pull this out.