### PR TITLE
[task] Modify default kafka group id

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,7 @@ func Get() *TrackerConfig {
 
 	// kafka config
 	options.SetDefault("kafka.timeout", 10000)
-	options.SetDefault("kafka.group.id", "payload-tracker-go")
+	options.SetDefault("kafka.group.id", "payload_tracker")
 	options.SetDefault("kafka.auto.offset.reset", "latest")
 	options.SetDefault("kafka.auto.commit.interval.ms", 5000)
 	options.SetDefault("kafka.request.required.acks", -1) // -1 == "all"


### PR DESCRIPTION
We should use the same group that the old payload tracker implementation
was using

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>