### PR TITLE
feat: support org_id for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Simply send a message on the ‘platform.payload-status’ for your given Kafka 
     'service': 'The services name processing the payload',
     'source': 'This is indicative of a third party rule hit analysis. (not Insights Client)',
     'account': 'The RH associated account',
+    'org_ig': 'The RH associated org id',
     'request_id': 'The ID of the payload',
     'inventory_id': 'The ID of the entity in terms of the inventory',
     'system_id': 'The ID of the entity in terms of the actual system',

--- a/api/api.spec.yaml
+++ b/api/api.spec.yaml
@@ -341,6 +341,7 @@ definitions:
         type: string
       org_id:
         title: Org ID
+        description: Identifies the organization that the given resource belongs to
         type: string
       request_id:
         title: Request ID

--- a/api/api.spec.yaml
+++ b/api/api.spec.yaml
@@ -31,7 +31,7 @@ paths:
           required: false
           type: string
           default: created_at
-          enum: [account, inventory_id, system_id, created_at]
+          enum: [account, org_id, inventory_id, system_id, created_at]
         - name: sort_dir
           in: query
           description: Direction to sort
@@ -43,6 +43,11 @@ paths:
           in: query
           required: false
           description: filter for account
+          type: string
+        - name: org_id
+          in: query
+          required: false
+          description: filter for org_id
           type: string
         - name: inventory_id
           in: query
@@ -334,6 +339,9 @@ definitions:
       account:
         title: Account
         type: string
+      org_id:
+        title: Org ID
+        type: string
       request_id:
         title: Request ID
         type: string
@@ -372,6 +380,9 @@ definitions:
         minLength: 1
       account:
         title: Account
+        type: string
+      org_id:
+        title: Org ID
         type: string
       inventory_id:
         title: Inventory ID

--- a/internal/db_methods/db_methods.go
+++ b/internal/db_methods/db_methods.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	payloadFields         = []string{"payloads.id", "payloads.request_id"}
-	extraPayloadFields    = []string{"payloads.account", "payloads.system_id", "payloads.inventory_id"}
+	extraPayloadFields    = []string{"payloads.account", "payloads.org_id", "payloads.system_id", "payloads.inventory_id"}
 	payloadStatusesFields = []string{"payload_statuses.status_msg", "payload_statuses.date", "payload_statuses.created_at"}
 	otherFields           = []string{"services.name as service", "sources.name as source", "statuses.name as status"}
 )
@@ -98,6 +98,9 @@ var RetrievePayloads = func(page int, pageSize int, apiQuery structs.Query) (int
 	// query chaining
 	if apiQuery.Account != "" {
 		dbQuery = dbQuery.Where("account = ?", apiQuery.Account)
+	}
+	if apiQuery.OrgID != "" {
+		dbQuery = dbQuery.Where("org_id = ?", apiQuery.OrgID)
 	}
 	if apiQuery.InventoryID != "" {
 		dbQuery = dbQuery.Where("inventory_id = ?", apiQuery.InventoryID)

--- a/internal/db_methods/db_methods.go
+++ b/internal/db_methods/db_methods.go
@@ -22,7 +22,7 @@ var (
 func defineVerbosity(verbosity string) string {
 	switch verbosity {
 	case "1":
-		queryFields := []string{otherFields[0], otherFields[2], extraPayloadFields[2], payloadStatusesFields[1], payloadStatusesFields[0]}
+		queryFields := []string{otherFields[0], otherFields[2], extraPayloadFields[3], payloadStatusesFields[1], payloadStatusesFields[0]}
 		return strings.Join(queryFields, ",")
 	case "2":
 		queryFields := []string{otherFields[0], otherFields[2], payloadStatusesFields[1]}

--- a/internal/endpoints/payloads_test.go
+++ b/internal/endpoints/payloads_test.go
@@ -51,6 +51,7 @@ func dataPerVerbosity(requestId string, verbosity string, d1 time.Time) structs.
 			ID:          1,
 			Service:     "puptoo",
 			Account:     "test",
+			OrgID:       "123456",
 			RequestID:   requestId,
 			InventoryID: getUUID(),
 			SystemID:    getUUID(),
@@ -322,6 +323,7 @@ var _ = Describe("RequestIdPayloads", func() {
 				Expect(respData.Data[0].ID).To(Equal(reqIdPayloads[0].ID))
 				Expect(respData.Data[0].Service).To(Equal(reqIdPayloads[0].Service))
 				Expect(respData.Data[0].Account).To(Equal(reqIdPayloads[0].Account))
+				Expect(respData.Data[0].OrgID).To(Equal(reqIdPayloads[0].OrgID))
 				Expect(respData.Data[0].RequestID).To(Equal(reqIdPayloads[0].RequestID))
 				Expect(respData.Data[0].InventoryID).To(Equal(reqIdPayloads[0].InventoryID))
 				Expect(respData.Data[0].SystemID).To(Equal(reqIdPayloads[0].SystemID))
@@ -397,6 +399,7 @@ var _ = Describe("RequestIdPayloads", func() {
 				Expect(respData.Data[0].ID).To(Equal(reqIdPayloads[0].ID))
 				Expect(respData.Data[0].Service).To(Equal(reqIdPayloads[0].Service))
 				Expect(respData.Data[0].Account).To(Equal(reqIdPayloads[0].Account))
+				Expect(respData.Data[0].OrgID).To(Equal(reqIdPayloads[0].OrgID))
 				Expect(respData.Data[0].RequestID).To(Equal(reqIdPayloads[0].RequestID))
 				Expect(respData.Data[0].InventoryID).To(Equal(reqIdPayloads[0].InventoryID))
 				Expect(respData.Data[0].SystemID).To(Equal(reqIdPayloads[0].SystemID))

--- a/internal/endpoints/utils.go
+++ b/internal/endpoints/utils.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	validSortBy         = []string{"created_at", "account", "system_id", "inventory_id", "service", "source", "status_msg", "date", "request_id", "status"}
-	validAllSortBy      = []string{"account", "inventory_id", "system_id", "created_at"}
+	validSortBy         = []string{"created_at", "account", "org_id", "system_id", "inventory_id", "service", "source", "status_msg", "date", "request_id", "status"}
+	validAllSortBy      = []string{"account", "org_id", "inventory_id", "system_id", "created_at"}
 	validIDSortBy       = []string{"service", "source", "status_msg", "date", "created_at"}
 	validStatusesSortBy = []string{"service", "source", "request_id", "status", "status_msg", "date", "created_at"}
 	validSortDir        = []string{"asc", "desc"}
@@ -32,6 +32,7 @@ func initQuery(r *http.Request) (structs.Query, error) {
 		CreatedAtLTE: r.URL.Query().Get("created_at_lte"),
 		CreatedAtGTE: r.URL.Query().Get("created_at_gte"),
 		Account:      r.URL.Query().Get("account"),
+		OrgID:        r.URL.Query().Get("org_id"),
 
 		Service:   r.URL.Query().Get("service"),
 		Source:    r.URL.Query().Get("source"),

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -163,6 +163,7 @@ func createPayload(msg *message.PayloadStatusMessage) (table models.Payloads) {
 		Id:          msg.PayloadID,
 		RequestId:   msg.RequestID,
 		Account:     msg.Account,
+		OrgId:       msg.OrgID,
 		SystemId:    msg.SystemID,
 		CreatedAt:   msg.Date.Time,
 		InventoryId: msg.InventoryID,

--- a/internal/models/db/models.go
+++ b/internal/models/db/models.go
@@ -26,6 +26,7 @@ type Payloads struct {
 	InventoryId string    `json:"inventory_id" gorm:"type:varchar"`
 	SystemId    string    `json:"system_id" gorm:"type:varchar"`
 	CreatedAt   time.Time `gorm:"not null"`
+	OrgId       string    `json:"org_id" gorm:"type:varchar"`
 }
 
 type Services struct {

--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -17,6 +17,7 @@ type PayloadStatusMessage struct {
 	Service     string       `json:"service"`
 	Source      string       `json:"source,omitempty"`
 	Account     string       `json:"account,omitempty"`
+	OrgID		string		 `json:"org_id,omitempty"`
 	RequestID   string       `json:"request_id"`
 	InventoryID string       `json:"inventory_id,omitempty"`
 	SystemID    string       `json:"system_id,omitempty"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -26,6 +26,7 @@ type Payloads struct {
 	InventoryId string    `json:"inventory_id" gorm:"type:varchar"`
 	SystemId    string    `json:"system_id" gorm:"type:varchar"`
 	CreatedAt   time.Time `json:"created_at" gorm:"not null"`
+	OrgId       string    `json:"org_id" gorm:"varchar"`
 }
 
 type Services struct {

--- a/internal/queries/queries.go
+++ b/internal/queries/queries.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	StatusColumns = "payload_id, status_id, service_id, source_id, date, inventory_id, system_id, account"
+	StatusColumns = "payload_id, status_id, service_id, source_id, date, inventory_id, system_id, account, org_id"
 	PayloadJoins  = "left join Payloads on Payloads.id = PayloadStatuses.payload_id"
 )
 

--- a/internal/structs/api_structs.go
+++ b/internal/structs/api_structs.go
@@ -14,6 +14,7 @@ type Query struct {
 	SortBy       string
 	SortDir      string
 	Account      string
+	OrgID		 string
 	InventoryID  string
 	SystemID     string
 	CreatedAtLT  string
@@ -63,6 +64,7 @@ type SinglePayloadData struct {
 	Service     string    `json:"service,omitempty"`
 	Source      string    `json:"source,omitempty"`
 	Account     string    `json:"account,omitempty"`
+	OrgID       string    `json:"org_id,omitempty"`
 	RequestID   string    `json:"request_id,omitempty"`
 	InventoryID string    `json:"inventory_id,omitempty"`
 	SystemID    string    `json:"system_id,omitempty"`

--- a/tools/db-seeder/seed.json
+++ b/tools/db-seeder/seed.json
@@ -88,7 +88,8 @@
             "request_id": "150bed4601c24ea9be73db9b20acb635",
             "account": "foobar",
             "inventory_id": "cb91e19b7eb04750b48bc52ec482f669",
-            "system_id": "b51d65b352ba498fafe3bcf02751f549"
+            "system_id": "b51d65b352ba498fafe3bcf02751f549",
+            "org_id": "12345"
         },
         {
             "request_id": "33b727497c3940589fc5276e739235c6",


### PR DESCRIPTION
Add support for org_id in the database and for searching payloads.


## What?
Update the DB models and queries to support org_id similar to how we support account number

## Why?
We are switching to using the org-id as the main identifier for payloads. The payload tracker
should go along with this and support the change as well. This PR will make org_id a query
item and allow us to sort.

## How?
Updated the models for the DB, which in turn will do the migration in the database for us.
I also added a query and updated the api to hand back org_id along with the rest of the data
we were getting before.

## Testing
Tests were updated to validate that Org ID data was coming back successfully.

## Anything Else?
This is a big one so might deserve a look from a couple folks.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices