### PR TITLE
fix: Add metrics middleware for endpoints

### DIFF
--- a/cmd/payload-tracker-api/main.go
+++ b/cmd/payload-tracker-api/main.go
@@ -35,6 +35,7 @@ func main() {
 	mr := chi.NewRouter()
 	sub := chi.NewRouter()
 
+
 	// Mount the root of the api router on /api/v1
 	r.Mount("/api/v1/", sub)
 	r.Get("/", lubdub)
@@ -44,10 +45,10 @@ func main() {
 	mr.Get("/", lubdub)
 	mr.Handle("/metrics", promhttp.Handler())
 
-	sub.Get("/", lubdub)
-	sub.Get("/payloads", endpoints.Payloads)
-	sub.Get("/payloads/{request_id}", endpoints.RequestIdPayloads)
-	sub.Get("/statuses", endpoints.Statuses)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/", lubdub)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads", endpoints.Payloads)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}", endpoints.RequestIdPayloads)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/statuses", endpoints.Statuses)
 
 	srv := http.Server{
 		Addr:    ":" + cfg.PublicPort,


### PR DESCRIPTION
## What?
Adding the response metrics middleware to our endpoints so we can properly track metrics
related to the API.

## Why?
We require the metrics so we can understand the performance and usefulness of the app.

## How?
The ResponseMetricsMiddleware was already built out to provide a metrics collection for each
endpoint. We just hadn't wired it up yet. I added the middleware to the sub router for each
endpoint that we want to collect metrics on.

## Testing
No additional automated testing performed.

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices