### PR TITLE
feat(metrics): Enable consumer metrics

### DIFF
--- a/cmd/payload-tracker-consumer/main.go
+++ b/cmd/payload-tracker-consumer/main.go
@@ -2,12 +2,24 @@ package main
 
 import (
 	"context"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/redhatinsights/payload-tracker-go/internal/config"
 	"github.com/redhatinsights/payload-tracker-go/internal/db"
 	"github.com/redhatinsights/payload-tracker-go/internal/kafka"
 	"github.com/redhatinsights/payload-tracker-go/internal/logging"
 )
+
+
+func lubdub(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("lubdub"))
+}
+
 
 func main() {
 	logging.InitLogger()
@@ -20,11 +32,31 @@ func main() {
 
 	logging.Log.Info("Starting a new kafka consumer...")
 
+
+	// Webserver is created only for metrics collection
+	r := chi.NewRouter()
+
+	// Mount the metrics handler on /metrics
+	r.Get("/", lubdub)
+	r.Handle("/metrics", promhttp.Handler())
+
+	msrv := http.Server{
+		Addr:    ":" + cfg.MetricsPort,
+		Handler: r,
+	}
+
 	consumer, err := kafka.NewConsumer(ctx, cfg, cfg.KafkaConfig.KafkaTopic)
 
 	if err != nil {
 		logging.Log.Fatal("ERROR! ", err)
 	}
+
+	go func() {
+
+		if err := msrv.ListenAndServe(); err != nil {
+			panic(err)
+		}
+	}()
 
 	kafka.NewConsumerEventLoop(ctx, cfg, consumer, db.DB)
 }

--- a/internal/endpoints/metrics.go
+++ b/internal/endpoints/metrics.go
@@ -20,10 +20,30 @@ var (
 		Help: "Number of seconds spent waiting on a db response",
 	}, []string{})
 
+	messageProcessElapsed = pa.NewHistogramVec(p.HistogramOpts{
+        Name: "payload_tracker_message_process_seconds",
+		Help: "Number of seconds spent processing messages",
+	}, []string{})
+
+	messageProcessError = pa.NewCounterVec(p.CounterOpts{
+		Name: "payload_tracker_message_process_errors",
+		Help: "Count of message process errors",
+	}, []string{})
+
 	responseCodes = pa.NewCounterVec(p.CounterOpts{
 		Name: "payload_tracker_responses",
 		Help: "Count of response codes by code",
 	}, []string{"code"})
+
+	consumedMessages = pa.NewCounterVec(p.CounterOpts{
+		Name: "payload_tracker_consumed_messages",
+		Help: "Number of messages consumed by payload tracker",
+	}, []string{})
+
+	consumeError = pa.NewCounterVec(p.CounterOpts{
+        Name: "payload_tracker_consume_errors",
+		Help: "Number of consumer errors encountered",
+	}, []string{})
 )
 
 type metricTrackingResponseWriter struct {
@@ -35,8 +55,27 @@ func incRequests() {
 	requests.With(p.Labels{}).Inc()
 }
 
+// IncConsumedMessages increments the message count by 1
+func IncConsumedMessages() {
+	consumedMessages.With(p.Labels{}).Inc()
+}
+
+// IncConsumeFailure increments the failure count by 1
+func IncConsumeErrors() {
+	consumeError.With(p.Labels{}).Inc()
+}
+
+// IncMessageProcessErrors increments the error count by 1
+func IncMessageProcessErrors() {
+	messageProcessError.With(p.Labels{}).Inc()
+}
+
 func observeDBTime(elapsed time.Duration) {
 	dbElapsed.With(p.Labels{}).Observe(elapsed.Seconds())
+}
+
+func ObserveMessageProcessTime(elapsed time.Duration) {
+	messageProcessElapsed.With(p.Labels{}).Observe(elapsed.Seconds())
 }
 
 func (m *metricTrackingResponseWriter) Header() http.Header {

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -11,6 +11,7 @@ import (
 
 	config "github.com/redhatinsights/payload-tracker-go/internal/config"
 	l "github.com/redhatinsights/payload-tracker-go/internal/logging"
+	"github.com/redhatinsights/payload-tracker-go/internal/endpoints"
 )
 
 // NewConsumer Creates brand new consumer instance based on topic
@@ -88,9 +89,11 @@ func NewConsumerEventLoop(
 
 			switch e := event.(type) {
 			case *kafka.Message:
+				endpoints.IncConsumedMessages()
 				l.Log.Infof("message %s = %s\n", string(e.Key), string(e.Value))
 				handler.onMessage(ctx, e, cfg)
 			case kafka.Error:
+				endpoints.IncConsumeErrors()
 				l.Log.Fatalf("Consumer error: %v (%v)\n", e.Code(), e)
 				break
 			default:


### PR DESCRIPTION
Added a server for the /metrics endpoint in the consumer as well as a
handful of metrics worth grabbing from the consumer itself.

- message process errors
- message process elapsed time
- consumer failures
- total messages consumed

There's likely room for more cool stuff in here



## What?
Added a metrics endpoint to the consumer as well as some high level metric
collections that are specifically consumer based.

## Why?
Metrics give us insight into how the app is performing. The consumer currently has
no metrics endpoint so this resolves that blindspot.

## How?
Added a webservice that listens on / and /metrics. The /metrics endpoint is handled by
the prometheus handler that formats metrics that we want to collect.

The metrics themselves were added by adding counterVec and histogramVec options
depending on whether it was a count or a time based metric. I added metrics to count
total messages as well as total errors. I also count consumer failures as well as the 
total time it takes to process a single message.

## Testing
No added tests for the metrics

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices