### PR TITLE
Removed log message

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -52,8 +52,6 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	sanitizePayload(payloadStatus)
 
 	// Check if request_id not in Payloads Table and update columns
-	l.Log.Info("Sanitized Payload for DB ", payloadStatus)
-
 	payloadDump, err := getPayload(this.db, payloadStatus.RequestID)
 	if err != nil && err != gorm.ErrRecordNotFound {
 		l.Log.Error("ERROR: Sanitizing payload failed")


### PR DESCRIPTION
Since there is no error from the sanitize, this is a checkpoint log message that doubles the number of log messages for every payload. Which is a lot, perhaps it could be removed to save log processing/storage?