### PR TITLE
task: remove log message for each incoming message

### DIFF
--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -90,7 +90,6 @@ func NewConsumerEventLoop(
 			switch e := event.(type) {
 			case *kafka.Message:
 				endpoints.IncConsumedMessages()
-				l.Log.Infof("message %s = %s\n", string(e.Key), string(e.Value))
 				handler.onMessage(ctx, e, cfg)
 			case kafka.Error:
 				endpoints.IncConsumeErrors()


### PR DESCRIPTION
We're currently logginge every single message we consume, and we should
stop doing that


## What?
Remove the log message that we generate for every single incoming message

## Why?
Logging to cloudwatch can be expensive

## How?
Delete the line for the log

## Testing
Nope

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices