### PR TITLE
fix: Set the request_id validation to a bool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,6 @@ type CloudwatchCfg struct {
 }
 
 type RequestCfg struct {
-	ValidateRequestID       bool
 	ValidateRequestIDLength int
 }
 
@@ -81,7 +80,6 @@ func Get() *TrackerConfig {
 	options.SetDefault("kafka.retry.backoff.ms", 100)
 
 	// requestID config
-	options.SetDefault("validate.request.id", true)
 	options.SetDefault("validate.request.id.length", 32)
 
 	if clowder.IsClowderEnabled() {
@@ -157,7 +155,6 @@ func Get() *TrackerConfig {
 			CWSecretKey: options.GetString("cwSecretKey"),
 		},
 		RequestConfig: RequestCfg{
-			ValidateRequestID:       options.GetBool("validate.request.id"),
 			ValidateRequestIDLength: options.GetInt("validate.request.id.length"),
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ func Get() *TrackerConfig {
 	options.SetDefault("kafka.retry.backoff.ms", 100)
 
 	// requestID config
-	options.SetDefault("validate.request.id", "true")
+	options.SetDefault("validate.request.id", true)
 	options.SetDefault("validate.request.id.length", 32)
 
 	if clowder.IsClowderEnabled() {

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -43,7 +43,6 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	// Validate RequestID
 	if cfg.RequestConfig.ValidateRequestID {
 		if len(payloadStatus.RequestID) > cfg.RequestConfig.ValidateRequestIDLength {
-			l.Log.Errorf("ERROR: Payload {value} has invalid request_id length.")
 			return
 		}
 	}

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -41,7 +41,7 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	}
 
 	// Validate RequestID
-	if cfg.RequestConfig.ValidateRequestID {
+	if cfg.RequestConfig.ValidateRequestIDLength != 0 {
 		if len(payloadStatus.RequestID) > cfg.RequestConfig.ValidateRequestIDLength {
 			return
 		}


### PR DESCRIPTION
We expect a bool here but we're passing in a string. Could be the
reason our requestID length validator is failing

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Fixing a bug where we are trying to process yupana messages. These request_ids dont' fit our standard so we do not track them.

## Why?
Currently we are being overwhelmed by messages in payload tracker. This is mean to alleviate some DB pressure from frequent reads

## How?
Fixed the type in the config for this boolean. It was a set to a string by default, where it should actually be a bool

## Testing
N/A. We need to get some testing here though. The urgency of this bug is more important than the time spent build a full test suite.

## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
