### PR TITLE
Using upsert for payload inserts

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -50,32 +50,15 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	// Sanitize the payload
 	sanitizePayload(payloadStatus)
 
-	// Check if request_id not in Payloads Table and update columns
-	payloadDump, err := getPayload(this.db, payloadStatus.RequestID)
-	if err != nil && err != gorm.ErrRecordNotFound {
-		l.Log.Error("ERROR: Sanitizing payload failed")
+	// Upsert into Payloads Table
+	payload := createPayload(payloadStatus)
+
+	upsertResult := queries.UpsertPayloadByRequestId(this.db, payloadStatus.RequestID, payload)
+	if upsertResult.Error != nil {
+		l.Log.Error("ERROR Payload table upsert failed: ", upsertResult.Error)
 		return
 	}
-
-	if (models.Payloads{}) == payloadDump {
-		payload := createPayload(payloadStatus)
-
-		result, newPayload := queries.CreatePayloadTableEntry(this.db, payload)
-		if result.Error != nil {
-			l.Log.Error("ERROR Payload table entry creation Failed: ", result.Error)
-			return
-		}
-		sanitizedPayloadStatus.PayloadId = newPayload.Id
-	} else {
-		payloadsUpdate := createPayload(payloadStatus)
-
-		result := queries.UpdatePayloadsTable(this.db, payloadsUpdate, payloadDump)
-		if result.Error != nil {
-			l.Log.Error("ERROR Payload table update failed: ", result.Error)
-			return
-		}
-		sanitizedPayloadStatus.PayloadId = payloadDump.Id
-	}
+	sanitizedPayloadStatus.PayloadId = payload.Id
 
 	// Check if service/source/status are in table
 	// this section checks the subsiquent DB tables to see if the service_id, source_id, and status_id exist for the given message
@@ -155,10 +138,6 @@ func sanitizePayload(msg *message.PayloadStatusMessage) {
 	if msg.Source != "" {
 		msg.Source = strings.ToLower((msg.Source))
 	}
-}
-
-func getPayload(db *gorm.DB, request_id string) (results models.Payloads, err error) {
-	return queries.GetPayloadByRequestId(db, request_id)
 }
 
 func createPayload(msg *message.PayloadStatusMessage) (table models.Payloads) {

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -53,12 +53,12 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	// Upsert into Payloads Table
 	payload := createPayload(payloadStatus)
 
-	upsertResult := queries.UpsertPayloadByRequestId(this.db, payloadStatus.RequestID, payload)
+	upsertResult, payloadId := queries.UpsertPayloadByRequestId(this.db, payloadStatus.RequestID, payload)
 	if upsertResult.Error != nil {
 		l.Log.Error("ERROR Payload table upsert failed: ", upsertResult.Error)
 		return
 	}
-	sanitizedPayloadStatus.PayloadId = payload.Id
+	sanitizedPayloadStatus.PayloadId = payloadId
 
 	// Check if service/source/status are in table
 	// this section checks the subsiquent DB tables to see if the service_id, source_id, and status_id exist for the given message

--- a/internal/models/db/models.go
+++ b/internal/models/db/models.go
@@ -21,7 +21,7 @@ type PayloadStatuses struct {
 
 type Payloads struct {
 	Id          uint      `gorm:"primaryKey;not null;autoIncrement"`
-	RequestId   string    `json:"request_id" gorm:"not null;type:varchar"`
+	RequestId   string    `json:"request_id" gorm:"not null;type:varchar;unique"`
 	Account     string    `json:"account" gorm:"type:varchar"`
 	InventoryId string    `json:"inventory_id" gorm:"type:varchar"`
 	SystemId    string    `json:"system_id" gorm:"type:varchar"`

--- a/internal/queries/queries.go
+++ b/internal/queries/queries.go
@@ -44,14 +44,14 @@ func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloa
 	return payload, nil
 }
 
-func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB) {
-	result := tx.Model(models.Payloads{}).
+func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB, payloadId uint) {
+	result := db.Model(&payload).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "request_id"}},
 			DoUpdates: clause.AssignmentColumns([]string{"account", "inventory_id", "system_id", "org_id"}),
 		}).
 		Create(&payload)
-	return result
+	return result, payload.Id
 }
 
 func UpdatePayloadsTable(db *gorm.DB, updates models.Payloads, payloads models.Payloads) (tx *gorm.DB) {

--- a/internal/queries/queries.go
+++ b/internal/queries/queries.go
@@ -3,6 +3,7 @@ package queries
 import (
 	models "github.com/redhatinsights/payload-tracker-go/internal/models/db"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -41,6 +42,16 @@ func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloa
 	}
 
 	return payload, nil
+}
+
+func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB) {
+	result := tx.Model(models.Payloads{}).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "request_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{"account", "inventory_id", "system_id", "org_id"}),
+		}).
+		Create(&payload)
+	return result
 }
 
 func UpdatePayloadsTable(db *gorm.DB, updates models.Payloads, payloads models.Payloads) (tx *gorm.DB) {


### PR DESCRIPTION
## What?

Uses SQL `UPSERT` to create or update payloads in the db. When using upserts, we don't need to run a separate query to check whether or not a particular row already exists in the db.

## Why?
This PR reduces the number of SQL query we run for each valid kafka message we receive. Though, it may not solve all our current db write locking issues, it has the potential to reduce them. Fingers crossed.

## How?
* Uses gorm clause to use Upsert
* Explicitly sets local `Payloads request_id` field and `unique`. `OnConflict` does not work otherwise. 

## Testing
Only manual testing.

## Anything Else?
[Gorm UPSERT Documentation](https://gorm.io/docs/create.html#Upsert-On-Conflict)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
