### PR TITLE
Updated get payload by request id endpoint to return a 404 when a pay…

### DIFF
--- a/internal/endpoints/payloads.go
+++ b/internal/endpoints/payloads.go
@@ -77,7 +77,7 @@ func Payloads(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, http.StatusOK, string(dataJson))
 }
 
-// SinglePayload returns a resposne for /payloads/{request_id}
+// RequestIdPayloads returns a response for /payloads/{request_id}
 func RequestIdPayloads(w http.ResponseWriter, r *http.Request) {
 
 	reqID := chi.URLParam(r, "request_id")
@@ -102,6 +102,12 @@ func RequestIdPayloads(w http.ResponseWriter, r *http.Request) {
 	}
 
 	payloads := RetrieveRequestIdPayloads(reqID, q.SortBy, q.SortDir, verbosity)
+
+	if payloads == nil || len(payloads) == 0 {
+		writeResponse(w, http.StatusNotFound, getErrorBody("payload with id: "+reqID+" not found", http.StatusNotFound))
+		return
+	}
+
 	durations := db_methods.CalculateDurations(payloads)
 
 	payloadsData := structs.PayloadRetrievebyID{Data: payloads, Durations: durations}

--- a/internal/endpoints/payloads_test.go
+++ b/internal/endpoints/payloads_test.go
@@ -282,6 +282,44 @@ var _ = Describe("RequestIdPayloads", func() {
 			})
 		})
 
+		Context("with an invalid request id, and db returns empty set", func() {
+			It("should return HTTP 404", func() {
+				req, err := makeTestRequest(fmt.Sprintf("/api/v1/payloads/%s", requestId), query)
+				Expect(err).To(BeNil())
+
+				reqIdPayloadData = make([]structs.SinglePayloadData, 0)
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(404))
+				Expect(rr.Body).ToNot(BeNil())
+
+				var respData structs.ErrorResponse
+
+				readBody, _ := ioutil.ReadAll(rr.Body)
+				json.Unmarshal(readBody, &respData)
+
+				Expect(respData.Status).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		Context("with an invalid request id, and db returns nil", func() {
+			It("should return HTTP 404", func() {
+				req, err := makeTestRequest(fmt.Sprintf("/api/v1/payloads/%s", requestId), query)
+				Expect(err).To(BeNil())
+
+				reqIdPayloadData = nil
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(404))
+				Expect(rr.Body).ToNot(BeNil())
+
+				var respData structs.ErrorResponse
+
+				readBody, _ := ioutil.ReadAll(rr.Body)
+				json.Unmarshal(readBody, &respData)
+
+				Expect(respData.Status).To(Equal(http.StatusNotFound))
+			})
+		})
+
 		Context("With invalid sort_dir parameter", func() {
 			It("should return HTTP 400", func() {
 				query["sort_dir"] = "des"


### PR DESCRIPTION
## What?
Updated the 'get payload by request id' endpoint to return a 404 when a payload with the given request id is not found. Currently it returns a 500.
https://issues.redhat.com/browse/RHCLOUD-18326

## Why?
To align with proper http status codes

## How?
The current implementation is attempting to access elements from an empty array that is returned from the db when a payload with the given request id is not found. This results in an 'index out of bounds' exception, which results in a 500. A check is added in this pr for an empty or nil array after querying the db.

## Testing
Unit test, manual testing locally

## Anything Else?
N/A

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
