### PR TITLE
[docs] Add account and org-id to required values

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Please see the Swagger Spec for API Endpoints. The API Swagger Spec is located i
 
 
 ## Message Formats
-Simply send a message on the ‘platform.payload-status’ for your given Kafka MQ Broker in the appropriate environment. Currently, the only required fields are ‘service,’ ‘request_id,‘ ‘status,’ and ‘date‘ however this may change.The format is as follows:
+Simply send a message on the ‘platform.payload-status’ for your given Kafka MQ Broker in the appropriate environment. Currently, the following fields are required:
+
+    org_id
+    service
+    request_id
+    status
+    data
 
 ```
 { 	


### PR DESCRIPTION
The org_id will eventually be the only required field, but for now I'm
throwing account in there as well since Ingress needs it to verify
whether someone can view a payload. That should be updated soon.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Added a comment about the required field in a payload message

## Why?
we need status that are submitted to contain some info about the owner of the payload. This is so that a user can search for it if needed.

## How?
Just updated the doc

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
