### PR TITLE
fix: don't add Z to timestamps with timezone info

### DIFF
--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -40,16 +40,16 @@ func (t *FormatedTime) UnmarshalJSON(b []byte) error {
 	}
 
 	date = strings.Join(strings.Fields(date), "T")
-	
-	// Add a Z to the end of the timestamp if it doesn't exist
-	if !strings.HasSuffix(date, "Z") {
-		date = date + "Z"
-	}
 
 	t.Time, err = time.Parse(dateFormat, date)
 	if err != nil {
-		l.Log.Error("ERROR: Parsing date into new format: ", err)
-		return err
+		// Probably not timezone aware timestamp, add Z to the end
+		date = date + "Z"
+		t.Time, err = time.Parse(dateFormat, date)
+		if err != nil {
+			l.Log.Error("ERROR: Parsing date into new format: ", err)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## What?
if other app sends timestamp like `2022-05-24T08:49:38+00:00`, the parsing will fail because payload-tracker adds `Z` to the end and creates invalid date format which can't be parsed.
```
parsing time \"2022-05-24T08:49:38+00:00Z\": extra text: \"Z\"
```

## Why?
`2022-05-24T08:49:38+00:00` and `2022-05-24T08:49:38Z` are both valid date formats under RFC3339, `2022-05-24T08:49:38+00:00Z` is not. 

## How?
Add `Z` only when date parsing fails.

## Testing
no


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
