### PR TITLE
Adding tests for kafka onMessage

### DIFF
--- a/internal/kafka/handler_suite_test.go
+++ b/internal/kafka/handler_suite_test.go
@@ -1,0 +1,15 @@
+package kafka
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	l "github.com/redhatinsights/payload-tracker-go/internal/logging"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	l.InitLogger()
+	RunSpecs(t, "Kafka Message Handler Suite")
+}

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -1,5 +1,97 @@
 package kafka
 
-// TODO: Add imports here
+import (
+	"context"
+	"encoding/json"
+	"time"
 
-// TODO: Add Tests here
+	k "github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhatinsights/payload-tracker-go/internal/config"
+	"github.com/redhatinsights/payload-tracker-go/internal/models/message"
+	"github.com/redhatinsights/payload-tracker-go/internal/queries"
+	"github.com/redhatinsights/payload-tracker-go/internal/utils/test"
+)
+
+func newKafkaMessage(value message.PayloadStatusMessage) *k.Message {
+	msgValue, err := json.Marshal(value)
+	Expect(err).ToNot(HaveOccurred())
+
+	topic := "topic.payload.status"
+
+	return &k.Message{
+		Value: msgValue,
+		TopicPartition: k.TopicPartition{
+			Topic:     &topic,
+			Partition: 0,
+			Offset:    k.Offset(0),
+		},
+	}
+}
+
+func getSimplePayloadStatusMessage() message.PayloadStatusMessage {
+	date, _ := time.Parse(time.RFC3339, "2022-06-07T11:00:10.356Z")
+	return message.PayloadStatusMessage{
+		Service:     "puptoo",
+		Source:      "test-source",
+		Account:     "1234",
+		OrgID:       "5678",
+		RequestID:   "e4b3d38f199f4abdb1cfbcf6e3b81f56",
+		InventoryID: "0e71e590-19e8-456e-8439-6cec9a1ae074",
+		SystemID:    "ef49a293-64f3-4945-9797-fc9fe6ec73e1",
+		Status:      "success",
+		StatusMSG:   "done",
+		Date:        message.FormatedTime{date},
+	}
+}
+
+var _ = Describe("Kafka message handler", func() {
+	var msgHandler handler
+
+	db := test.WithDatabase()
+
+	BeforeEach(func() {
+		msgHandler = handler{
+			db: db(),
+		}
+	})
+
+	Describe("On valid payload status message", func() {
+		It("Creates the required DB entries", func() {
+			payloadMsgVal := getSimplePayloadStatusMessage()
+			payloadStatusMessage := newKafkaMessage(payloadMsgVal)
+
+			msgHandler.onMessage(context.Background(), payloadStatusMessage, config.Get())
+
+			dbResult := queries.RetrieveRequestIdPayloads(db(), payloadMsgVal.RequestID, "created_at", "asc", "0")
+
+			Expect(dbResult[0].Service).To(Equal(payloadMsgVal.Service))
+			Expect(dbResult[0].Account).To(Equal(payloadMsgVal.Account))
+			Expect(dbResult[0].OrgID).To(Equal(payloadMsgVal.OrgID))
+			Expect(dbResult[0].RequestID).To(Equal(payloadMsgVal.RequestID))
+			Expect(dbResult[0].InventoryID).To(Equal(payloadMsgVal.InventoryID))
+			Expect(dbResult[0].SystemID).To(Equal(payloadMsgVal.SystemID))
+			Expect(dbResult[0].Status).To(Equal(payloadMsgVal.Status))
+			Expect(dbResult[0].StatusMsg).To(Equal(payloadMsgVal.StatusMSG))
+			Expect(dbResult[0].Source).To(Equal(payloadMsgVal.Source))
+		})
+	})
+
+	Describe("On longer request id length", func() {
+		It("Does not create db entries", func() {
+			payloadMsgVal := getSimplePayloadStatusMessage()
+			payloadMsgVal.RequestID = uuid.New().String() // Default max request id length in 32 (equal to UUID without any dashes). This produces an UUID with dashes. e.g. > 32
+
+			payloadStatusMessage := newKafkaMessage(payloadMsgVal)
+
+			msgHandler.onMessage(context.Background(), payloadStatusMessage, config.Get())
+
+			dbResult := queries.RetrieveRequestIdPayloads(db(), payloadMsgVal.RequestID, "created_at", "asc", "0")
+
+			Expect(len(dbResult)).To(Equal(0))
+		})
+	})
+})


### PR DESCRIPTION
## What?
This PR adds tests to the payload-tracker consumer's Kafka OnMessage function. 
This work is done as part of [this ticket](https://issues.redhat.com/browse/RHCLOUD-19058).

## Why?
The kafka `onMessage` function in `internal/kafka/handler.go` is the core of the payload-tracker consumer and we currently do not have any tests for it. I am opening this PR to change that. These tests might prevent us from pushing out changes that might crash the consumer.

## How?
Added 2 tests that covers almost all of the `onMessage` function.

## Testing
:arrow_up: 

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
