### PR TITLE
Add timeout to storage-broker /archive/url request

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -66,6 +66,8 @@ objects:
         env:
           - name: LOG_LEVEL
             value: ${LOGLEVEL}
+          - name: STORAGEBROKERURL
+            value: ${STORAGE_BROKER_URL}
     - name: consumer
       minReplicas: ${{CONSUMER_REPLICAS}}
       podSpec:  
@@ -166,3 +168,5 @@ parameters:
   required: true
 - name: CLEANER_SUSPEND
   value: 'true'
+- name: STORAGE_BROKER_URL
+  value: "http://storage-broker-processor:8000/archive/url"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,17 +10,18 @@ import (
 )
 
 type TrackerConfig struct {
-	Environment          string
-	PublicPort           string
-	MetricsPort          string
-	LogLevel             string
-	Hostname             string
-	StorageBrokerURL     string
-	StorageBrokerURLRole string
-	KafkaConfig          KafkaCfg
-	CloudwatchConfig     CloudwatchCfg
-	DatabaseConfig       DatabaseCfg
-	RequestConfig        RequestCfg
+	Environment                 string
+	PublicPort                  string
+	MetricsPort                 string
+	LogLevel                    string
+	Hostname                    string
+	StorageBrokerURL            string
+	StorageBrokerURLRole        string
+	StorageBrokerRequestTimeout int
+	KafkaConfig                 KafkaCfg
+	CloudwatchConfig            CloudwatchCfg
+	DatabaseConfig              DatabaseCfg
+	RequestConfig               RequestCfg
 }
 
 type KafkaCfg struct {
@@ -91,6 +92,7 @@ func Get() *TrackerConfig {
 	// storage broker config
 	options.SetDefault("storageBrokerURL", "http://storage-broker-processor:8000/archive/url")
 	options.SetDefault("storageBrokerURLRole", "platform-archive-download")
+	options.SetDefault("storageBrokerRequestTimeout", 10000)
 
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig
@@ -136,13 +138,14 @@ func Get() *TrackerConfig {
 	options.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	trackerCfg := &TrackerConfig{
-		Environment:          options.GetString("Environment"),
-		Hostname:             options.GetString("Hostname"),
-		LogLevel:             options.GetString("logLevel"),
-		PublicPort:           options.GetString("publicPort"),
-		MetricsPort:          options.GetString("metricsPort"),
-		StorageBrokerURL:     options.GetString("storageBrokerURL"),
-		StorageBrokerURLRole: options.GetString("storageBrokerURLRole"),
+		Environment:                 options.GetString("Environment"),
+		Hostname:                    options.GetString("Hostname"),
+		LogLevel:                    options.GetString("logLevel"),
+		PublicPort:                  options.GetString("publicPort"),
+		MetricsPort:                 options.GetString("metricsPort"),
+		StorageBrokerURL:            options.GetString("storageBrokerURL"),
+		StorageBrokerURLRole:        options.GetString("storageBrokerURLRole"),
+		StorageBrokerRequestTimeout: options.GetInt("storageBrokerRequestTimeout"),
 		KafkaConfig: KafkaCfg{
 			KafkaTimeout:               options.GetInt("kafka.timeout"),
 			KafkaGroupID:               options.GetString("kafka.group.id"),

--- a/internal/endpoints/utils.go
+++ b/internal/endpoints/utils.go
@@ -163,7 +163,12 @@ func writeResponse(w http.ResponseWriter, status int, message string) {
 
 // Send a request for an ArchiveLink to storage-broker
 func requestArchiveLink(r *http.Request, reqID string) (*structs.PayloadArchiveLink, error) {
-	response, err := http.Get(config.Get().StorageBrokerURL + "?request_id=" + reqID)
+	cfg := config.Get()
+	client := http.Client{
+		Timeout: time.Duration(cfg.StorageBrokerRequestTimeout),
+	}
+
+	response, err := client.Get(config.Get().StorageBrokerURL + "?request_id=" + reqID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endpoints/utils.go
+++ b/internal/endpoints/utils.go
@@ -165,7 +165,7 @@ func writeResponse(w http.ResponseWriter, status int, message string) {
 func requestArchiveLink(r *http.Request, reqID string) (*structs.PayloadArchiveLink, error) {
 	cfg := config.Get()
 	client := http.Client{
-		Timeout: time.Duration(cfg.StorageBrokerRequestTimeout),
+		Timeout: time.Duration(cfg.StorageBrokerRequestTimeout) * time.Millisecond,
 	}
 
 	response, err := client.Get(config.Get().StorageBrokerURL + "?request_id=" + reqID)


### PR DESCRIPTION
## What?
Add a timeout for the request that the `/archiveLink` endpoint sends to storage-broker's `/archive/url` endpoint.

## Why?
This should avoid crashing storage-broker with hanging requests from the endpoint.

## How?
A timeout is added to the `/archiveLink` endpoint

## Testing
No additional tests were added.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
