### PR TITLE
Increase /archiveLink timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,7 @@ func Get() *TrackerConfig {
 	// storage broker config
 	options.SetDefault("storageBrokerURL", "http://storage-broker-processor:8000/archive/url")
 	options.SetDefault("storageBrokerURLRole", "platform-archive-download")
-	options.SetDefault("storageBrokerRequestTimeout", 10000)
+	options.SetDefault("storageBrokerRequestTimeout", 35000)
 
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig


### PR DESCRIPTION
## What?
Increase time before /archiveLink request timeout

## Why?
Give storage-broker enough time to return the url for the archive