### PR TITLE
[fix] Accept only request IDs of a valid length

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -42,7 +42,7 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 
 	// Validate RequestID
 	if cfg.RequestConfig.ValidateRequestIDLength != 0 {
-		if len(payloadStatus.RequestID) > cfg.RequestConfig.ValidateRequestIDLength {
+		if len(payloadStatus.RequestID) != cfg.RequestConfig.ValidateRequestIDLength {
 			return
 		}
 	}


### PR DESCRIPTION
We currently are accepting shorter request_ids which is resulting in a
lot of test payloads with a -1 ID getting through. We don't want that

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Make it so valid request IDs *must* be 32 characters in length

## Why?
The only real valid ids we get are 32 characters. We were checking for ids longer than that, but not shorter. That resulted in us pulling in a ton of `-1` ids from test accounts and such. This will filter those out as well

## How?
Make it so the length must match 32.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
