### PR TITLE
fix cacert for kafka sasl

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,8 +183,10 @@ func Get() *TrackerConfig {
 			trackerCfg.KafkaConfig.KafkaPassword = *broker.Sasl.Password
 			trackerCfg.KafkaConfig.SASLMechanism = *broker.Sasl.SaslMechanism
 			trackerCfg.KafkaConfig.Protocol = *broker.Sasl.SecurityProtocol
-
-			// write the Kafka CA path using the app-common-go package
+		}
+		
+		// write the Kafka CA path using the app-common-go package
+		if broker.Cacert != nil {
 			caPath, err := clowder.LoadedConfig.KafkaCa(broker)
 
 			if err != nil {
@@ -192,8 +194,8 @@ func Get() *TrackerConfig {
 			}
 
 			trackerCfg.KafkaConfig.KafkaCA = caPath
-
 		}
+
 
 		// write the RDS CA using the app-common-go package
 		if clowder.LoadedConfig.Database.RdsCa != nil {


### PR DESCRIPTION
need to check for the existence of kafka cacert before we assume it's
there

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
check for cacert before we try to apply it

## Why?
The managed kafka system doesn't provide a cacert, but fedramp does. We need to make this mroe forgivable

## How?
Update the config

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
