### PR TITLE
[fix]set our id in payloads to be a bigint

### DIFF
--- a/internal/migration/main.go
+++ b/internal/migration/main.go
@@ -22,5 +22,7 @@ func main() {
 		&models.Payloads{},
 	)
 
+	db.DB.Exec("ALTER TABLE payloads ALTER COLUMN id type bigint")
+
 	logging.Log.Info("DB Migration Complete")
 }


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Modifies the ID column in payloads to be a bigint

## Why?
We have so many rows in that table that we're out of IDs

## How?
db exec to alter the table. This wont' hurt to run several times

## Testing
tested locally

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
