### PR TITLE
[fix] stop consumer reboot on error

### DIFF
--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -93,8 +93,7 @@ func NewConsumerEventLoop(
 				handler.onMessage(ctx, e, cfg)
 			case kafka.Error:
 				endpoints.IncConsumeErrors()
-				l.Log.Fatalf("Consumer error: %v (%v)\n", e.Code(), e)
-				break
+				l.Log.Errorf("Consumer error: %v (%v)\n", e.Code(), e)
 			default:
 				l.Log.Infof("Ignored %v\n", e)
 			}


### PR DESCRIPTION
This break message was causing the consumer to completely die anytime we
get a kafka error. In managed Kafka, we often see disconnects as a
"normal" state. We need to not reboot with every error. The library
should be able to recover when this happens without a reboot.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Remove the break from consumer error so our pods don't reboot

## Why?
Managed Kafka frequently sends disconnects when consumers are idle and we dont' want our consumer to restart every time this happens.

## How?
Remove the break and set the Fatal error to Error instead.

## Testing
Witnessed the behavior during the managed kafka test

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
