### PR TITLE
[test] Add ability to get a mock url for payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ Compile the source code for API and Consumer into a go binary:
 $> make build-all
 ```
 Launch the application
+
+The mock requestor implementation allows you to get payload URLS from the local
+machine
 ```
-$> ./pt-api
+$> REQUESTOR_IMPL=mock ./pt-api
 $> ./pt-consumer
 ```
 The API should now be available on TCP port 8080
@@ -96,7 +99,7 @@ $> make build-all
 ```
 Launch the application in DEV mode
 ```
-$> ENVIRONMENT=DEV ./pt-api
+$> ENVIRONMENT=DEV REQUESTOR_IMPL=mock ./pt-api
 $> ./pt-consumer
 ```
 The API should now be available on port 8080

--- a/cmd/payload-tracker-api/main.go
+++ b/cmd/payload-tracker-api/main.go
@@ -45,6 +45,11 @@ func main() {
 	} else {
 		r.Mount("/api/v1/", sub)
 	}
+
+	if cfg.RequestConfig.RequestorImpl == "mock" {
+		sub.Get("/archive/{id}", endpoints.ArchiveHandler)
+	}
+
 	r.Get("/", lubdub)
 	r.Get("/health", healthHandler)
 

--- a/cmd/payload-tracker-api/main.go
+++ b/cmd/payload-tracker-api/main.go
@@ -31,6 +31,10 @@ func main() {
 		*cfg,
 	)
 
+	linkHandler := endpoints.LinkHandler(
+		*cfg,
+	)
+
 	r := chi.NewRouter()
 	mr := chi.NewRouter()
 	sub := chi.NewRouter()
@@ -51,7 +55,7 @@ func main() {
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/", lubdub)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads", endpoints.Payloads)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}", endpoints.RequestIdPayloads)
-	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/archiveLink", endpoints.PayloadArchiveLink)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/archiveLink", linkHandler)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/roles/archiveLink", endpoints.RolesArchiveLink)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/statuses", endpoints.Statuses)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type CloudwatchCfg struct {
 
 type RequestCfg struct {
 	ValidateRequestIDLength int
+	RequestorImpl			string
 }
 
 // Get sets each config option with its defaults
@@ -88,6 +89,7 @@ func Get() *TrackerConfig {
 
 	// requestID config
 	options.SetDefault("validate.request.id.length", 32)
+	options.SetDefault("requestor.impl", "storage-broker")
 
 	// storage broker config
 	options.SetDefault("storageBrokerURL", "http://storage-broker-processor:8000/archive/url")
@@ -172,6 +174,7 @@ func Get() *TrackerConfig {
 		},
 		RequestConfig: RequestCfg{
 			ValidateRequestIDLength: options.GetInt("validate.request.id.length"),
+			RequestorImpl:            options.GetString("requestor.impl"),
 		},
 	}
 

--- a/internal/endpoints/payloads.go
+++ b/internal/endpoints/payloads.go
@@ -25,6 +25,19 @@ var (
 	verbosity string = "0"
 )
 
+func LinkHandler(cfg config.TrackerConfig) http.HandlerFunc {
+	switch cfg.RequestConfig.RequestorImpl {
+	case "storage-broker":
+		return PayloadArchiveLink
+	case "mock":
+		return MockArchiveLink
+	default:
+		l.Log.Errorf("Requestor implementation %s not supported", cfg.RequestConfig.RequestorImpl)
+		return nil
+	}
+}
+	
+
 // Payloads returns responses for the /payloads endpoint
 func Payloads(w http.ResponseWriter, r *http.Request) {
 
@@ -161,5 +174,16 @@ func PayloadArchiveLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	l.Log.Infof("Link generated for payload %s from identity %s: %s", reqID, r.Header.Get("x-rh-identity"), string(dataJson))
+	writeResponse(w, http.StatusOK, string(dataJson))
+}
+
+func MockArchiveLink(w http.ResponseWriter, r *http.Request) {
+	reqID := chi.URLParam(r, "request_id")
+
+	response := &structs.PayloadArchiveLink{
+					Url: "https://storage-broker.example.com/archive/" + reqID,
+				}
+	dataJson, _ := json.Marshal(response)
+
 	writeResponse(w, http.StatusOK, string(dataJson))
 }

--- a/internal/endpoints/payloads.go
+++ b/internal/endpoints/payloads.go
@@ -36,7 +36,6 @@ func LinkHandler(cfg config.TrackerConfig) http.HandlerFunc {
 		return nil
 	}
 }
-	
 
 // Payloads returns responses for the /payloads endpoint
 func Payloads(w http.ResponseWriter, r *http.Request) {
@@ -179,10 +178,11 @@ func PayloadArchiveLink(w http.ResponseWriter, r *http.Request) {
 
 func MockArchiveLink(w http.ResponseWriter, r *http.Request) {
 	reqID := chi.URLParam(r, "request_id")
+	url := fmt.Sprintf("http://%s:%s/api/v1/archive/%s", config.Get().Hostname, config.Get().PublicPort, reqID)
 
 	response := &structs.PayloadArchiveLink{
-					Url: "https://storage-broker.example.com/archive/" + reqID,
-				}
+		Url: url,
+	}
 	dataJson, _ := json.Marshal(response)
 
 	writeResponse(w, http.StatusOK, string(dataJson))

--- a/internal/endpoints/utils.go
+++ b/internal/endpoints/utils.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/redhatinsights/payload-tracker-go/internal/config"
 	"github.com/redhatinsights/payload-tracker-go/internal/db"
@@ -190,4 +191,11 @@ func requestArchiveLink(r *http.Request, reqID string) (*structs.PayloadArchiveL
 func isValidUUID(id string) bool {
 	_, err := uuid.Parse(id)
 	return err == nil
+}
+
+func ArchiveHandler(w http.ResponseWriter, r *http.Request) {
+	reqId := chi.URLParam(r, "id")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("You got an archive for " + reqId))
+	return
 }


### PR DESCRIPTION
We need a way to grab a URL for a payload without having to standup a
bunch of extra stuff to do it. This commit adds the ability, but does
not add an actual archive that we pull down.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?

Add a way to get a mock payload url

## Why?

Testing is good. This also helps local development as we can test the url feature
without having to standup all the extra stuff.

## How?

We wrap the archive link stuff into a handler that checks for the configured 
implementation before deciding which function to use. If we set REQUESTOR_IMPL to
`mock` then it uses the mocked implementation. By default we use the `storage-broker`
impl which is the behavior we want in stage/prod.

## Testing

None yet.

## Anything Else?

This might need more work. Especially if we want to pull down an actual file. 
There's some complicated stuff related to that as we can't guarantee that two 
different containers will share a filesystem. So we'd need some link in the api that
acts as a host for those files. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
