### PR TITLE
Add Kibana Link Endpoint [RHCLOUD-20313]

### DIFF
--- a/api/api.spec.yaml
+++ b/api/api.spec.yaml
@@ -182,6 +182,45 @@ paths:
           $ref: '#/responses/Forbidden'
         '404':
           $ref: '#/responses/NotFound'
+    /payloads/{request_id}/kibanaLink:
+      get:
+        description: Get the URL for a payload's Kibana dashboard
+        parameters: 
+          - name: request_id
+            in: path
+            description: A unique value identifying this payload.
+            required: true
+            type: string
+          - name: service
+            in: query
+            description: Service to get archive link for
+            required: false
+            type: string
+        responses:
+          '200':
+            description: ''
+            schema:
+              type: object
+              required:
+                - data
+              properties:
+                data:
+                  type: object
+                  required:
+                    - url
+                  properties:
+                    url:
+                      type: string
+                      description: URL to the payload's Kibana dashboard
+                      format: url
+          '400':
+            $ref: '#/responses/BadRequest'
+          '403':
+            $ref: '#/responses/Forbidden'
+          '404':
+            $ref: '#/responses/NotFound'
+          '500':
+            $ref: '#/responses/InternalServerError'
 
   /roles/archiveLink:
     get:

--- a/cmd/payload-tracker-api/main.go
+++ b/cmd/payload-tracker-api/main.go
@@ -65,6 +65,7 @@ func main() {
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads", endpoints.Payloads)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}", endpoints.RequestIdPayloads)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/archiveLink", linkHandler)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/kibanaLink", endpoints.PayloadKibanaLink)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/roles/archiveLink", endpoints.RolesArchiveLink)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/statuses", endpoints.Statuses)
 

--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -68,6 +68,12 @@ objects:
             value: ${LOGLEVEL}
           - name: STORAGEBROKERURL
             value: ${STORAGE_BROKER_URL}
+          - name: KIBANA_DASHBOARD_URL
+            value: ${KIBANA_DASHBOARD_URL}
+          - name: KIBANA_INDEX
+            value: ${KIBANA_INDEX}
+          - name: KIBANA_SERVICE_FIELD
+            value: ${KIBANA_SERVICE_FIELD}
     - name: consumer
       minReplicas: ${{CONSUMER_REPLICAS}}
       podSpec:  
@@ -170,3 +176,9 @@ parameters:
   value: 'true'
 - name: STORAGE_BROKER_URL
   value: "http://storage-broker-processor:8000/archive/url"
+- name: KIBANA_DASHBOARD_URL
+  value: https://kibana.apps.crcs02ue1.urby.p1.openshiftapps.com/app/kibana#/discover
+- name: KIBANA_INDEX
+  value: 4b37e920-1ade-11ec-b3d0-a39435352faa
+- name: KIBANA_SERVICE_FIELD
+  value: app

--- a/internal/structs/api_structs.go
+++ b/internal/structs/api_structs.go
@@ -49,6 +49,10 @@ type PayloadArchiveLink struct {
 	Url string `json:"url"`
 }
 
+type PayloadKibanaLink struct {
+	Url string `json:"url"`
+}
+
 type ArchiveLinkRole struct {
 	Allowed bool `json:"allowed"`
 }


### PR DESCRIPTION
## What?
Added an additional endpoint to generate the correct Kibana dashboard url for the front-end. 
(See https://github.com/RedHatInsights/payload-tracker-frontend/pull/106)

## Why?
Allow users to quickly view all logs for a specific request_id in Kibana

## How?
Uses the request_id and the optional service name sent by the user to generate a URL. The search index (grabbed from the Kibana dashboard), Kibana dashboard URL, and service field are all configurable through clowder.

## Testing
Added tests for the new endpoint.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
