### PR TITLE
[fix] add proper path to mock url

### DIFF
--- a/internal/endpoints/payloads.go
+++ b/internal/endpoints/payloads.go
@@ -179,7 +179,7 @@ func PayloadArchiveLink(w http.ResponseWriter, r *http.Request) {
 
 func MockArchiveLink(w http.ResponseWriter, r *http.Request) {
 	reqID := chi.URLParam(r, "request_id")
-	url := fmt.Sprintf("http://%s:%s/api/v1/archive/%s", config.Get().Hostname, config.Get().PublicPort, reqID)
+	url := fmt.Sprintf("http://%s:%s/app/payload-tracker/api/v1/archive/%s", config.Get().Hostname, config.Get().PublicPort, reqID)
 
 	response := &structs.PayloadArchiveLink{
 		Url: url,


### PR DESCRIPTION
We need /app/payload-tracker to be in the path when sending mock urls.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Explain what the change is linking any relevant JIRAs or Issues.

Add /app/payload-tracker to mock url

## Why?
Consider what business or engineering goal does this PR achieves.

in order to work with the frontend, we need this path to be correct

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

Add it to the string formatting in MockArchiveLinker

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
