### PR TITLE
Allow Request IDs to be null

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
@@ -41,8 +42,10 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	}
 
 	// Validate RequestID
+	valuePayloadStatus := reflect.ValueOf(payloadStatus)
+	requestField := valuePayloadStatus.Elem().FieldByName("request_id")
 	if cfg.RequestConfig.ValidateRequestIDLength != 0 {
-		if len(payloadStatus.RequestID) != cfg.RequestConfig.ValidateRequestIDLength {
+		if len(payloadStatus.RequestID) != cfg.RequestConfig.ValidateRequestIDLength || !requestField.IsValid() {
 			endpoints.IncInvalidConsumerRequestIDs()
 			return
 		}

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -43,7 +43,7 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 
 	// Validate RequestID
 	valuePayloadStatus := reflect.ValueOf(payloadStatus)
-	requestField := valuePayloadStatus.Elem().FieldByName("request_id")
+	requestField := valuePayloadStatus.Elem().FieldByName("RequestID")
 	if cfg.RequestConfig.ValidateRequestIDLength != 0 {
 		if len(payloadStatus.RequestID) != cfg.RequestConfig.ValidateRequestIDLength || !requestField.IsValid() {
 			endpoints.IncInvalidConsumerRequestIDs()

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -94,4 +94,21 @@ var _ = Describe("Kafka message handler", func() {
 			Expect(len(dbResult)).To(Equal(0))
 		})
 	})
+
+	Describe("On request id defined as nil", func() {
+		It("Does not create db entries", func() {
+			payloadMsgVal := message.PayloadStatusMessage{
+				Service: "test",
+				Status:  "success",
+			}
+
+			payloadStatusMessage := newKafkaMessage(payloadMsgVal)
+
+			msgHandler.onMessage(context.Background(), payloadStatusMessage, config.Get())
+
+			dbResult := queries.RetrieveRequestIdPayloads(db(), payloadMsgVal.RequestID, "created_at", "asc", "0")
+
+			Expect(len(dbResult)).To(Equal(0))
+		})
+	})
 })

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -80,6 +80,16 @@ var _ = Describe("Kafka message handler", func() {
 		})
 	})
 
+	Describe("On valid request ID", func() {
+		It("Succeeds and returns true", func() {
+			requestID := "e4b3d38f199f4abdb1cfbcf6e3b81f56"
+
+			validationResult := validateRequestID(32, requestID)
+
+			Expect(validationResult).To(Equal(true))
+		})
+	})
+
 	Describe("On invalid request ID", func() {
 		It("Fails on a request ID of invalid length", func() {
 			requestID := uuid.New().String() // Default max request id length in 32 (equal to UUID without any dashes). This produces an UUID with dashes. e.g. > 32

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -80,27 +80,26 @@ var _ = Describe("Kafka message handler", func() {
 		})
 	})
 
-	Describe("On longer request id length", func() {
+	Describe("On invalid request ID", func() {
+		It("Fails on a request ID of invalid length", func() {
+			requestID := uuid.New().String() // Default max request id length in 32 (equal to UUID without any dashes). This produces an UUID with dashes. e.g. > 32
+
+			validationResult := validateRequestID(32, requestID)
+
+			Expect(validationResult).To(Equal(false))
+		})
+
+		It("Fails on undeclared request ID", func() {
+			requestID := ""
+
+			validationResult := validateRequestID(32, requestID)
+
+			Expect(validationResult).To(Equal(false))
+		})
+
 		It("Does not create db entries", func() {
 			payloadMsgVal := getSimplePayloadStatusMessage()
 			payloadMsgVal.RequestID = uuid.New().String() // Default max request id length in 32 (equal to UUID without any dashes). This produces an UUID with dashes. e.g. > 32
-
-			payloadStatusMessage := newKafkaMessage(payloadMsgVal)
-
-			msgHandler.onMessage(context.Background(), payloadStatusMessage, config.Get())
-
-			dbResult := queries.RetrieveRequestIdPayloads(db(), payloadMsgVal.RequestID, "created_at", "asc", "0")
-
-			Expect(len(dbResult)).To(Equal(0))
-		})
-	})
-
-	Describe("On request id defined as nil", func() {
-		It("Does not create db entries", func() {
-			payloadMsgVal := message.PayloadStatusMessage{
-				Service: "test",
-				Status:  "success",
-			}
 
 			payloadStatusMessage := newKafkaMessage(payloadMsgVal)
 

--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -18,7 +18,7 @@ type PayloadStatusMessage struct {
 	Source      string `json:"source,omitempty"`
 	Account     string `json:"account,omitempty"`
 	OrgID       string `json:"org_id,omitempty"`
-	RequestID   string `json:"request_id"`
+	RequestID   string `json:"request_id,omitempty"`
 	InventoryID string `json:"inventory_id,omitempty"`
 	SystemID    string `json:"system_id,omitempty"`
 	Status      string `json:"status"`


### PR DESCRIPTION
## What?
Allow Payload Tracker to accept Request IDs of null.

## Why?
The inventory team is implementing a feature that can make RequestIDs appear to be null instead of -1.  As such the Payload Tracker needs to accomodate this change and reject those messages.

## How?
Updated the payloadMessage model to be omitempty and added in a check to identify null / undefined request_ids

## Testing
Added unit testing for this feature and added a test that "consumes" a message without a request_id.

## Anything Else?
JIRA: https://issues.redhat.com/browse/RHCLOUD-21023

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
