### PR TITLE
SkipDefaultTransaction for DB write events [RHCLOUD-20753]

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -22,7 +22,7 @@ func DbConnect(cfg *config.TrackerConfig) {
 	)
 	dsn := fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=disable", user, password, dbname, host, port)
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{SkipDefaultTransaction: true})
 	if err != nil {
 		l.Log.Fatal(err)
 	}

--- a/internal/utils/test/fixtures.go
+++ b/internal/utils/test/fixtures.go
@@ -28,7 +28,7 @@ func WithDatabase() func() *gorm.DB {
 
 		dsn := fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=disable", user, password, dbname, host, port)
 
-		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{SkipDefaultTransaction: true})
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
## What?
Skipping default transaction for gorm DB write events

## Why?
Gorm documentation mentions that disabling default transaction for db write events (create/update/delete) will improve query performance by over 30%.

The payload tracker db gets overwhelmed very easily, disabling default transactions might help us improve the overall performance of the payload tracker service.

Gorm documentation on how to disable default transaction: [here](https://gorm.io/docs/transactions.html#Disable-Default-Transaction)

## How?
* Setting `SkipDefaultTransaction` flag to `true.
* Manually doing all the db write transactions of the consumer inside a gorm transaction block.

## Testing
n/a
Current unit tests is sufficient enough to avoid the introduction of any major bugs.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
