### PR TITLE
Remove unused redis from docker file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -37,9 +37,3 @@ services:
             - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
             - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
             - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-    redis:
-        image: registry.redhat.io/rhel8/redis-5
-        ports:
-            - 6379:6379
-        depends_on:
-            - payload-tracker-db


### PR DESCRIPTION
## What?
Removed Redis from the docker file.

## Why?
Redis 5 is deprecated and no longer being used in the project.

## How?

## Testing
Existing tests still passing after removing Redis

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
