### PR TITLE
[RHCLOUD-21720] Log more info about failed request_id unmarshal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type TrackerConfig struct {
 	DatabaseConfig              DatabaseCfg
 	RequestConfig               RequestCfg
 	KibanaConfig                KibanaCfg
+	DebugConfig                 DebugCfg
 }
 
 type KafkaCfg struct {
@@ -70,6 +71,10 @@ type KibanaCfg struct {
 	ServiceField string
 }
 
+type DebugCfg struct {
+	LogRawStatusEvent bool
+}
+
 // Get sets each config option with its defaults
 func Get() *TrackerConfig {
 	options := viper.New()
@@ -110,6 +115,9 @@ func Get() *TrackerConfig {
 	options.SetDefault("kibana.url", "https://kibana.apps.crcs02ue1.urby.p1.openshiftapps.com/app/kibana#/discover")
 	options.SetDefault("kibana.index", "43c5fed0-d5ce-11ea-b58c-a7c95afd7a5d") // the index grabbed from the kibana url
 	options.SetDefault("kibana.service.field", "app")
+
+	// debug config
+	options.SetDefault("debug.logRawStatusEvent", false)
 
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig
@@ -197,6 +205,9 @@ func Get() *TrackerConfig {
 			DashboardURL: options.GetString("kibana.url"),
 			Index:        options.GetString("kibana.index"),
 			ServiceField: options.GetString("kibana.service.field"),
+		},
+		DebugConfig: DebugCfg{
+			LogRawStatusEvent: options.GetBool("debug.logRawStatusEvent"),
 		},
 	}
 

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -36,7 +36,11 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 
 	if err := json.Unmarshal(msg.Value, payloadStatus); err != nil {
 		// PROBE: Add probe here for error unmarshaling JSON
-		l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)
+		if cfg.DebugConfig.LogRawStatusEvent {
+			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err, " Raw Message: ", string(msg.Value))
+		} else {
+			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)
+		}
 		return
 	}
 

--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -18,7 +18,7 @@ type PayloadStatusMessage struct {
 	Source      string `json:"source,omitempty"`
 	Account     string `json:"account,omitempty"`
 	OrgID       string `json:"org_id,omitempty"`
-	RequestID   string `json:"request_id,omitempty"` // This accomodates request_id being sent as a string or number
+	RequestID   string `json:"request_id,omitempty"`
 	InventoryID string `json:"inventory_id,omitempty"`
 	SystemID    string `json:"system_id,omitempty"`
 	Status      string `json:"status"`

--- a/internal/models/message/payload-status.go
+++ b/internal/models/message/payload-status.go
@@ -18,7 +18,7 @@ type PayloadStatusMessage struct {
 	Source      string `json:"source,omitempty"`
 	Account     string `json:"account,omitempty"`
 	OrgID       string `json:"org_id,omitempty"`
-	RequestID   string `json:"request_id,omitempty"`
+	RequestID   string `json:"request_id,omitempty"` // This accomodates request_id being sent as a string or number
 	InventoryID string `json:"inventory_id,omitempty"`
 	SystemID    string `json:"system_id,omitempty"`
 	Status      string `json:"status"`


### PR DESCRIPTION
## What?
Change config to allow logging of the raw Json from Kafka payloadStatusEvent for debugging

## Why?
To investigate the following error occasionally occurring in payload-tracker's logs:
```
ERROR: Unmarshaling Payload Status Event: json: cannot unmarshal number into Go struct field PayloadStatusMessage.request_id of type string 
```

## How?
Logging the raw Json from Kafka payloadStatusEvent to check the source of the incorrectly formatted UUIDs

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
