### PR TITLE
Clarify which request fields are UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Simply send a message on the ‘platform.payload-status’ for your given Kafka 
     'source': 'This is indicative of a third party rule hit analysis. (not Insights Client)',
     'account': 'The RH associated account',
     'org_id': 'The RH associated org id',
-    'request_id': 'The ID of the payload',
-    'inventory_id': 'The ID of the entity in terms of the inventory',
-    'system_id': 'The ID of the entity in terms of the actual system',
+    'request_id': 'The ID of the payload (This should be a UUID)',
+    'inventory_id': 'The ID of the entity in terms of the inventory (This should be a UUID)',
+    'system_id': 'The ID of the entity in terms of the actual system (This should be a UUID)',
     'status': 'received|processing|success|error|etc',
     'status_msg': 'Information relating to the above status, should more verbiage be needed (in the event of an error)',
     'date': 'Timestamp for the message relating to the status above. (This should be in RFC3339 UTC format: "2022-03-17T16:56:10Z")'

--- a/api/api.spec.yaml
+++ b/api/api.spec.yaml
@@ -54,10 +54,12 @@ paths:
           required: false
           description: filter for inventory_id
           type: string
+          format: uuid
         - name: system_id
           in: query
           required: false
           type: string
+          format: uuid
         - name: created_at_lt
           in: query
           required: false
@@ -132,6 +134,7 @@ paths:
         description: A unique value identifying this payload.
         required: true
         type: string
+        format: uuid
       - name: sort_by
         in: query
         description: Attribute to sort results by
@@ -162,6 +165,7 @@ paths:
           description: A unique value identifying this payload.
           required: true
           type: string
+          format: uuid
       responses:
         '200':
           description: ''
@@ -196,6 +200,7 @@ paths:
           description: A unique value identifying this payload.
           required: true
           type: string
+          format: uuid
         - name: service
           in: query
           description: Service to get archive link for
@@ -455,12 +460,15 @@ definitions:
         title: Request ID
         type: string
         minLength: 1
+        format: uuid
       inventory_id:
         title: Inventory ID
         type: string
+        format: uuid
       system_id:
         title: System ID
         type: string
+        format: uuid
       status:
         title: Status
         type: string
@@ -487,6 +495,7 @@ definitions:
         title: Request ID
         type: string
         minLength: 1
+        format: uuid
       account:
         title: Account
         type: string
@@ -496,9 +505,11 @@ definitions:
       inventory_id:
         title: Inventory ID
         type: string
+        format: uuid
       system_id:
         title: System ID
         type: string
+        format: uuid
       created_at:
         title: Created at
         type: string
@@ -520,6 +531,7 @@ definitions:
         title: Request ID
         type: string
         minLength: 1
+        format: uuid
       status:
         title: Status
         type: string


### PR DESCRIPTION
## What?
Clearly define which request fields are required to be a UUID.

## Why?
To avoid other services sending incompatible IDs in their requests

## How?
Updated the README and api.spec to clarify UUID fields

## Testing

## Anything Else?
Related to the error we were seeing when sent a non-UUID request_id as part of [RHCLOUD-21720](https://issues.redhat.com/browse/RHCLOUD-21720)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
