### PR TITLE
Fix config for logging status event json

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -74,6 +74,8 @@ objects:
             value: ${KIBANA_INDEX}
           - name: KIBANA_SERVICE_FIELD
             value: ${KIBANA_SERVICE_FIELD}
+          - name: DEBUG_LOG_STATUS_JSON
+            value: ${DEBUG_LOG_STATUS_JSON}
     - name: consumer
       minReplicas: ${{CONSUMER_REPLICAS}}
       podSpec:  
@@ -182,3 +184,5 @@ parameters:
   value: 4b37e920-1ade-11ec-b3d0-a39435352faa
 - name: KIBANA_SERVICE_FIELD
   value: app
+- name: DEBUG_LOG_STATUS_JSON
+  value: 'false'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type KibanaCfg struct {
 }
 
 type DebugCfg struct {
-	LogRawStatusEvent bool
+	LogStatusJson bool
 }
 
 // Get sets each config option with its defaults
@@ -117,7 +117,7 @@ func Get() *TrackerConfig {
 	options.SetDefault("kibana.service.field", "app")
 
 	// debug config
-	options.SetDefault("debug.logRawStatusEvent", false)
+	options.SetDefault("debug.log.status.json", false)
 
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig
@@ -207,7 +207,7 @@ func Get() *TrackerConfig {
 			ServiceField: options.GetString("kibana.service.field"),
 		},
 		DebugConfig: DebugCfg{
-			LogRawStatusEvent: options.GetBool("debug.logRawStatusEvent"),
+			LogStatusJson: options.GetBool("debug.log.status.json"),
 		},
 	}
 

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -36,7 +36,7 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 
 	if err := json.Unmarshal(msg.Value, payloadStatus); err != nil {
 		// PROBE: Add probe here for error unmarshaling JSON
-		if cfg.DebugConfig.LogRawStatusEvent {
+		if cfg.DebugConfig.LogStatusJson {
 			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err, " Raw Message: ", string(msg.Value))
 		} else {
 			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)


### PR DESCRIPTION
## What?
Fixes for the log config I missed in https://github.com/RedHatInsights/payload-tracker-go/pull/125

## Why?
I missed these changes in my original PR, so clowder wasn't changing the config setting

## How?
Allow clowder to set the `debug.log.status.json` to log the json for PayloadStatusEvents that fail to unmarshal.

## Testing

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
