### PR TITLE
Change the record count calculation so that the records are not retrieved from the database

### DIFF
--- a/internal/queries/queries_api.go
+++ b/internal/queries/queries_api.go
@@ -109,7 +109,7 @@ var RetrievePayloads = func(dbQuery *gorm.DB, page int, pageSize int, apiQuery s
 
 	orderString := fmt.Sprintf("%s %s", apiQuery.SortBy, apiQuery.SortDir)
 
-	dbQuery.Find(&payloads).Count(&count)
+	dbQuery.Model(&payloads).Count(&count)
 	dbQuery.Order(orderString).Limit(pageSize).Offset(pageSize * page).Find(&payloads)
 
 	return count, payloads
@@ -158,7 +158,7 @@ var RetrieveStatuses = func(dbQuery *gorm.DB, apiQuery structs.Query) (int64, []
 	dbQuery = chainTimeConditions("payload_statuses.created_at", apiQuery, dbQuery)
 
 	orderString := fmt.Sprintf("%s %s", apiQuery.SortBy, apiQuery.SortDir)
-	dbQuery.Scan(&payloads).Count(&count)
+	dbQuery.Model(&payloads).Count(&count)
 	dbQuery.Order(orderString).Limit(pageSize).Offset(pageSize * page).Scan(&payloads)
 
 	return count, payloads


### PR DESCRIPTION
## What?
Change the record count calculation so that the records are not retrieved from the database

## Why?
Loading the main frontend page appears to be causing the pods to get OOM killed.  It looks like the calculation of the payload count field is possibly trying to grab all of the payload records from the database when loading the main page.  This is because there are no selection criteria selected.  When this happens, the memory usage on the pod shoots up to 1gb and the pod falls over.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
