### PR TITLE
Close the response from the http client to avoid a memory leak

### DIFF
--- a/cmd/payload-tracker-api/main.go
+++ b/cmd/payload-tracker-api/main.go
@@ -33,7 +33,7 @@ func main() {
 		*cfg,
 	)
 
-	linkHandler := endpoints.LinkHandler(
+	payloadArchiveLinkHandler := endpoints.CreatePayloadArchiveLinkHandler(
 		*cfg,
 	)
 
@@ -64,7 +64,7 @@ func main() {
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/", lubdub)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads", endpoints.Payloads)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}", endpoints.RequestIdPayloads)
-	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/archiveLink", linkHandler)
+	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/archiveLink", payloadArchiveLinkHandler)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/payloads/{request_id}/kibanaLink", endpoints.PayloadKibanaLink)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/roles/archiveLink", endpoints.RolesArchiveLink)
 	sub.With(endpoints.ResponseMetricsMiddleware).Get("/statuses", endpoints.Statuses)


### PR DESCRIPTION
## What?
Close the response from the http client to avoid a memory leak.

I tried to avoid changing the behavior of the service, but I did change how the unit test works.  With this change, the unit tests mocks out the storage broker service.  This allows the test to cover more of the code.

The implementation of the method that retrieves the payload archive link from storage broker is passed into the PayloadArchiveLink http handler method when the service starts up.

## Why?
The response from the http client needs to be closed other wise it will cause a memory leak.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
