### PR TITLE
[fix] Make clowdapp name match app-interface Template

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: payload-tracker
+  name: payload-tracker-go
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: payload-tracker
+    name: payload-tracker-go
   spec:
     optionalDependencies:
     - storage-broker


### PR DESCRIPTION
The clowdapp name has to match the app interface template in order for
optionalDependencies and Dependencies work properly with bonfire.

The easiest place to fix this is here in the clowdapp file since
changing it elsewhere would require changes to both the apps referencing
it as well as the resource name in app-interface

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## What?
Update the clowdapp name to match the name in app-interface

## Why?
If the name in the clowdapp and the name in app-interface do not match, bonfire can not properly use the optionalDependencies or Dependencies list

## How?
Change the name

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
