### PR TITLE
feat: Add https support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/prometheus/client_golang v1.11.0
-	github.com/redhatinsights/app-common-go v1.6.3
+	github.com/redhatinsights/app-common-go v1.6.6
 	github.com/redhatinsights/platform-go-middlewares v0.9.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/redhatinsights/app-common-go v1.6.3 h1:HhjDKLBqQM5i8Ii58WLi5hG+lTNaKgpAEnJ2vdVUJtw=
 github.com/redhatinsights/app-common-go v1.6.3/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
+github.com/redhatinsights/app-common-go v1.6.6 h1:daOwCpGtW6IxGd9iO6TY3yoaV/HaHKjo/j/05dV0hHM=
+github.com/redhatinsights/app-common-go v1.6.6/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redhatinsights/platform-go-middlewares v0.9.0 h1:gDKP4XI+ppZdTRfVGJYBENdMM58hKlbVUzXBaY32F/I=
 github.com/redhatinsights/platform-go-middlewares v0.9.0/go.mod h1:koDaxx4Ht3ZgXqAhfkKFhBy9586kZ3aDm9IAlEs0Oo4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type TrackerConfig struct {
 	StorageBrokerURL            string
 	StorageBrokerURLRole        string
 	StorageBrokerRequestTimeout int
+	TlsCAPath                   string
 	KafkaConfig                 KafkaCfg
 	CloudwatchConfig            CloudwatchCfg
 	DatabaseConfig              DatabaseCfg
@@ -111,11 +112,12 @@ func Get() *TrackerConfig {
 	options.SetDefault("storageBrokerURL", "http://storage-broker-processor:8000/archive/url")
 	options.SetDefault("storageBrokerURLRole", "platform-archive-download")
 	options.SetDefault("storageBrokerRequestTimeout", 35000)
+	options.SetDefault("TlsCAPath", "")
+
 	// kibana config
 	options.SetDefault("kibana.url", "https://kibana.apps.crcs02ue1.urby.p1.openshiftapps.com/app/kibana#/discover")
 	options.SetDefault("kibana.index", "43c5fed0-d5ce-11ea-b58c-a7c95afd7a5d") // the index grabbed from the kibana url
 	options.SetDefault("kibana.service.field", "app")
-
 	// debug config
 	options.SetDefault("debug.log.status.json", false)
 
@@ -128,6 +130,7 @@ func Get() *TrackerConfig {
 		// ports
 		options.SetDefault("publicPort", cfg.PublicPort)
 		options.SetDefault("metricsPort", cfg.MetricsPort)
+		options.SetDefault("TlsCAPath", cfg.TlsCAPath)
 		// database
 		options.SetDefault("db.user", cfg.Database.Username)
 		options.SetDefault("db.password", cfg.Database.Password)
@@ -172,6 +175,7 @@ func Get() *TrackerConfig {
 		StorageBrokerURL:            options.GetString("storageBrokerURL"),
 		StorageBrokerURLRole:        options.GetString("storageBrokerURLRole"),
 		StorageBrokerRequestTimeout: options.GetInt("storageBrokerRequestTimeout"),
+		TlsCAPath: 		     options.GetString("TlsCAPath"),
 		KafkaConfig: KafkaCfg{
 			KafkaTimeout:               options.GetInt("kafka.timeout"),
 			KafkaGroupID:               options.GetString("kafka.group.id"),

--- a/internal/endpoints/payloads.go
+++ b/internal/endpoints/payloads.go
@@ -25,7 +25,7 @@ var (
 func CreatePayloadArchiveLinkHandler(cfg config.TrackerConfig) http.HandlerFunc {
 	switch cfg.RequestConfig.RequestorImpl {
 	case "storage-broker":
-		return PayloadArchiveLink(RequestArchiveLink(cfg.StorageBrokerURL, cfg.StorageBrokerRequestTimeout))
+		return PayloadArchiveLink(RequestArchiveLink(cfg))
 	case "mock":
 		return MockArchiveLink
 	default:

--- a/internal/endpoints/payloads_test.go
+++ b/internal/endpoints/payloads_test.go
@@ -452,7 +452,12 @@ var _ = Describe("PayloadArchiveLink", func() {
 			w.Write([]byte("{\"url\": \"www.example.com\"}"))
 		}))
 
-		handler = http.HandlerFunc(endpoints.PayloadArchiveLink(endpoints.RequestArchiveLink(mockStorageBrokerServer.URL, 10)))
+		cfg := config.TrackerConfig{
+			StorageBrokerURL: mockStorageBrokerServer.URL,
+			StorageBrokerRequestTimeout: 10,
+		}
+
+		handler = http.HandlerFunc(endpoints.PayloadArchiveLink(endpoints.RequestArchiveLink(cfg)))
 
 		requestId = getUUID()
 		query = make(map[string]interface{})


### PR DESCRIPTION
Add a client so queries to storage broker can be https enabled

## What?
Enable an https client if we have a CA in the clowdapp

## Why?
Future platform changes are going to require HTTPS connections between apps

## How?
If we have a tlsCAPath configured, we will create a TLS enabled https client for talking to storage broker

## Testing
Tested with the tests we already have

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
