### PR TITLE
make sslmode a toggle

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,8 +19,14 @@ func DbConnect(cfg *config.TrackerConfig) {
 		dbname   = cfg.DatabaseConfig.DBName
 		host     = cfg.DatabaseConfig.DBHost
 		port     = cfg.DatabaseConfig.DBPort
+		sslmode  = "disable"
 	)
-	dsn := fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=disable", user, password, dbname, host, port)
+
+	if cfg.DatabaseConfig.RDSCa != "" {
+		sslmode = "require"
+	}
+
+	dsn := fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=%s", user, password, dbname, host, port, sslmode)
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
We need to start using sslmode when the RDSCa is available

## What?
Make ssl mode a toggle

## Why?
We have sslmode set to disabled. In some environments where ssl is enforced, we need to make sure we can actually use SSL for databases.

## How?
If we have an RDSCa, then we turn SSL mode on for the database

## Testing
Ran `make test` 

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
