### PR TITLE
[RHCLOUD-22562] Add metric for total messages processed

### DIFF
--- a/internal/endpoints/metrics.go
+++ b/internal/endpoints/metrics.go
@@ -30,6 +30,11 @@ var (
 		Help: "Number of seconds spent waiting on a db response",
 	}, []string{})
 
+	messagesProcessed = pa.NewCounterVec(p.CounterOpts{
+		Name: "payload_tracker_messages_processed",
+		Help: "Count of total messages processed",
+	}, []string{})
+
 	messageProcessElapsed = pa.NewHistogramVec(p.HistogramOpts{
 		Name: "payload_tracker_message_process_seconds",
 		Help: "Number of seconds spent processing messages",
@@ -73,6 +78,11 @@ func IncConsumedMessages() {
 // IncConsumeFailure increments the failure count by 1
 func IncConsumeErrors() {
 	consumeError.With(p.Labels{}).Inc()
+}
+
+// IncMessageProcessed  increments the messages processed count by 1
+func IncMessagesProcessed() {
+	messagesProcessed.With(p.Labels{}).Inc()
 }
 
 // IncMessageProcessErrors increments the error count by 1

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -117,6 +117,7 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 
 	// Insert payload into DB
 	endpoints.ObserveMessageProcessTime(time.Since(start))
+	endpoints.IncMessagesProcessed()
 	result := queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
 	if result.Error != nil {
 		endpoints.IncMessageProcessErrors()


### PR DESCRIPTION
## What?
[RHCLOUD-22562](https://issues.redhat.com/browse/RHCLOUD-22562)
Track the total number of messages processed.

## Why?
Enable us to track number of failed/successful messages using this new metric and the existing `payload_tracker_message_process_errors` metric.

## How?
Add the metric `payload_tracker_messages_processed`.

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
