### PR TITLE
Make the binaries "phony" so that they are built each time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+.PHONY: pt-api pt-consumer pt-migration
+
 all: build-all
 
 build-all: pt-api pt-consumer pt-migration


### PR DESCRIPTION
Right now if you run make after modifying one of the golang source files, make doesn't rebuild the binaries.  This is kinda frustrating.  Golang compiles really fast...so just force Golang to build the binaries each time you run `make`.  