### PR TITLE
Do not update payload fields with empty strings

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -12,6 +12,7 @@ objects:
     optionalDependencies:
     - storage-broker
     - ingress
+    - rbac
     testing:
       iqePlugin: payload-tracker
     envName: ${ENV_NAME}

--- a/internal/queries/queries_consumer.go
+++ b/internal/queries/queries_consumer.go
@@ -45,19 +45,32 @@ func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloa
 }
 
 func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB, payloadId uint) {
-	columnsToUpdate := []string{"inventory_id", "system_id"}
+	columnsToUpdate := []string{}
+
 	if payload.Account != "" {
 		columnsToUpdate = append(columnsToUpdate, "account")
 	}
 	if payload.OrgId != "" {
 		columnsToUpdate = append(columnsToUpdate, "org_id")
 	}
-	result := db.Model(&payload).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "request_id"}},
-			DoUpdates: clause.AssignmentColumns(columnsToUpdate),
-		}).
-		Create(&payload)
+	if payload.InventoryId != "" {
+		columnsToUpdate = append(columnsToUpdate, "inventory_id")
+	}
+	if payload.SystemId != "" {
+		columnsToUpdate = append(columnsToUpdate, "system_id")
+	}
+
+	var result *gorm.DB
+	onConflict := clause.OnConflict{Columns: []clause.Column{{Name: "request_id"}}}
+
+	if len(columnsToUpdate) > 0 {
+		onConflict.DoUpdates = clause.AssignmentColumns(columnsToUpdate)
+	} else {
+		onConflict.DoNothing = true
+	}
+
+	result = db.Model(&payload).Clauses(onConflict).Create(&payload)
+
 	return result, payload.Id
 }
 

--- a/internal/queries/queries_consumer.go
+++ b/internal/queries/queries_consumer.go
@@ -45,10 +45,17 @@ func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloa
 }
 
 func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB, payloadId uint) {
+	columnsToUpdate := []string{"inventory_id", "system_id"}
+	if payload.Account != "" {
+		columnsToUpdate = append(columnsToUpdate, "account")
+	}
+	if payload.OrgId != "" {
+		columnsToUpdate = append(columnsToUpdate, "org_id")
+	}
 	result := db.Model(&payload).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "request_id"}},
-			DoUpdates: clause.AssignmentColumns([]string{"account", "inventory_id", "system_id", "org_id"}),
+			DoUpdates: clause.AssignmentColumns(columnsToUpdate),
 		}).
 		Create(&payload)
 	return result, payload.Id

--- a/internal/queries/queries_test.go
+++ b/internal/queries/queries_test.go
@@ -98,4 +98,64 @@ var _ = Describe("Queries", func() {
 		Expect(payload.Account).To(Equal("1234"))
 		Expect(payload.OrgId).To(Equal("1234"))
 	})
+	It("Updates without storing empty inventory_id/system_id for request id", func() {
+		requestId := getUUID()
+		inventoryId := getUUID()
+		systemId := getUUID()
+		payload := models.Payloads{
+			RequestId:   requestId,
+			Account:     "1234",
+			OrgId:       "1234",
+			InventoryId: inventoryId,
+			SystemId:    systemId,
+		}
+		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
+
+		payload = models.Payloads{
+			RequestId: requestId,
+			Account:   "5678",
+			OrgId:     "5678",
+		}
+
+		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		Expect(result.Error).ToNot(HaveOccurred())
+
+		payload, err := GetPayloadByRequestId(db(), requestId)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(payload.RequestId).To(Equal(requestId))
+		Expect(payload.InventoryId).To(Equal(inventoryId))
+		Expect(payload.SystemId).To(Equal(systemId))
+		Expect(payload.Account).To(Equal("5678"))
+		Expect(payload.OrgId).To(Equal("5678"))
+	})
+	It("Updates nothing if all fields are empty", func() {
+		requestId := getUUID()
+		inventoryId := getUUID()
+		systemId := getUUID()
+		payload := models.Payloads{
+			RequestId:   requestId,
+			Account:     "1234",
+			OrgId:       "1234",
+			InventoryId: inventoryId,
+			SystemId:    systemId,
+		}
+		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
+
+		payload = models.Payloads{
+			RequestId: requestId,
+		}
+
+		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		Expect(result.Error).ToNot(HaveOccurred())
+
+		payload, err := GetPayloadByRequestId(db(), requestId)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(payload.RequestId).To(Equal(requestId))
+		Expect(payload.InventoryId).To(Equal(inventoryId))
+		Expect(payload.SystemId).To(Equal(systemId))
+		Expect(payload.Account).To(Equal("1234"))
+		Expect(payload.OrgId).To(Equal("1234"))
+	})
 })

--- a/internal/queries/queries_test.go
+++ b/internal/queries/queries_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Queries", func() {
 		payload := models.Payloads{
 			RequestId:   requestId,
 			Account:     "1234",
+			OrgId:       "1234",
 			InventoryId: getUUID(),
 			SystemId:    getUUID(),
 		}
@@ -32,5 +33,69 @@ var _ = Describe("Queries", func() {
 
 		Expect(payload.RequestId).To(Equal(requestId))
 		Expect(payload.Account).To(Equal("1234"))
+		Expect(payload.OrgId).To(Equal("1234"))
+	})
+	It("Updates payload for request id", func() {
+		requestId := getUUID()
+		inventoryId := getUUID()
+		systemId := getUUID()
+		payload := models.Payloads{
+			RequestId:   requestId,
+			Account:     "1234",
+			OrgId:       "1234",
+			InventoryId: inventoryId,
+			SystemId:    systemId,
+		}
+		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
+
+		payload = models.Payloads{
+			RequestId:   requestId,
+			Account:     "5678",
+			OrgId:       "5678",
+			InventoryId: inventoryId,
+			SystemId:    systemId,
+		}
+
+		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		Expect(result.Error).ToNot(HaveOccurred())
+
+		payload, err := GetPayloadByRequestId(db(), requestId)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(payload.RequestId).To(Equal(requestId))
+		Expect(payload.InventoryId).To(Equal(inventoryId))
+		Expect(payload.Account).To(Equal("5678"))
+		Expect(payload.OrgId).To(Equal("5678"))
+	})
+	It("Updates without storing empty account/org_id for request id", func() {
+		requestId := getUUID()
+		inventoryId := getUUID()
+		systemId := getUUID()
+		payload := models.Payloads{
+			RequestId:   requestId,
+			Account:     "1234",
+			OrgId:       "1234",
+			InventoryId: inventoryId,
+			SystemId:    systemId,
+		}
+		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
+
+		payload = models.Payloads{
+			RequestId:   requestId,
+			InventoryId: getUUID(),
+			SystemId:    getUUID(),
+		}
+
+		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		Expect(result.Error).ToNot(HaveOccurred())
+
+		payload, err := GetPayloadByRequestId(db(), requestId)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(payload.RequestId).To(Equal(requestId))
+		Expect(payload.InventoryId).ToNot(Equal(inventoryId))
+		Expect(payload.SystemId).ToNot(Equal(systemId))
+		Expect(payload.Account).To(Equal("1234"))
+		Expect(payload.OrgId).To(Equal("1234"))
 	})
 })

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -21,7 +21,7 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 # source $APP_ROOT/unit_test.sh
 source $CICD_ROOT/deploy_ephemeral_env.sh
-oc rsh -n $NAMESPACE $(oc get pods -n $NAMESPACE -o name | grep "payload-tracker-api") ./pt-seeder
+oc rsh -n $NAMESPACE deployment/payload-tracker-api ./pt-seeder
 COMPONENT_NAME=payload-tracker
 source $CICD_ROOT/cji_smoke_test.sh
 source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
Some payload messages are arriving from certain services without the account or org_id populated, for example:
```
{"date": "2023-11-27T21:20:49.074675", "request_id": "e055ceb40f734fac8798ca1b38ea867f", "service": "inventory-mq-service", "status": "processing", "status_msg": "adding/updating host"}
```

This causes a payload for a certain request ID to have its `org_id` and `account` info wiped.

Technically, services are supposed to send messages with `org_id`, but at the same time payload-tracker could prevent this issue by not overwriting the `org_id`/`account` with an empty string. This PR will only update columns if they are not empty strings.