### PR TITLE
Remove use of DoNothing

### DIFF
--- a/internal/queries/queries_consumer.go
+++ b/internal/queries/queries_consumer.go
@@ -45,7 +45,7 @@ func GetPayloadByRequestId(db *gorm.DB, request_id string) (result models.Payloa
 }
 
 func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Payloads) (tx *gorm.DB, payloadId uint) {
-	columnsToUpdate := []string{}
+	columnsToUpdate := []string{"request_id"}
 
 	if payload.Account != "" {
 		columnsToUpdate = append(columnsToUpdate, "account")
@@ -60,16 +60,11 @@ func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Pay
 		columnsToUpdate = append(columnsToUpdate, "system_id")
 	}
 
-	var result *gorm.DB
-	onConflict := clause.OnConflict{Columns: []clause.Column{{Name: "request_id"}}}
-
-	if len(columnsToUpdate) > 0 {
-		onConflict.DoUpdates = clause.AssignmentColumns(columnsToUpdate)
-	} else {
-		onConflict.DoNothing = true
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{{Name: "request_id"}},
+		DoUpdates: clause.AssignmentColumns(columnsToUpdate),
 	}
-
-	result = db.Model(&payload).Clauses(onConflict).Create(&payload)
+	result := db.Model(&payload).Clauses(onConflict).Create(&payload)
 
 	return result, payload.Id
 }

--- a/internal/queries/queries_consumer.go
+++ b/internal/queries/queries_consumer.go
@@ -64,6 +64,7 @@ func UpsertPayloadByRequestId(db *gorm.DB, request_id string, payload models.Pay
 		Columns: []clause.Column{{Name: "request_id"}},
 		DoUpdates: clause.AssignmentColumns(columnsToUpdate),
 	}
+
 	result := db.Model(&payload).Clauses(onConflict).Create(&payload)
 
 	return result, payload.Id

--- a/internal/queries/queries_test.go
+++ b/internal/queries/queries_test.go
@@ -145,11 +145,11 @@ var _ = Describe("Queries", func() {
 		}
 		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
 
-		newPayload := models.Payloads{
+		payload = models.Payloads{
 			RequestId: requestId,
 		}
 
-		result, id := UpsertPayloadByRequestId(db(), requestId, newPayload)
+		result, id := UpsertPayloadByRequestId(db(), requestId, payload)
 		Expect(result.Error).ToNot(HaveOccurred())
 		Expect(id).ToNot(Equal(uint(0)))
 
@@ -161,6 +161,5 @@ var _ = Describe("Queries", func() {
 		Expect(payload.SystemId).To(Equal(systemId))
 		Expect(payload.Account).To(Equal("1234"))
 		Expect(payload.OrgId).To(Equal("1234"))
-		Expect(payload.Id).ToNot(Equal(0))
 	})
 })

--- a/internal/queries/queries_test.go
+++ b/internal/queries/queries_test.go
@@ -56,8 +56,9 @@ var _ = Describe("Queries", func() {
 			SystemId:    systemId,
 		}
 
-		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		result, id := UpsertPayloadByRequestId(db(), requestId, payload)
 		Expect(result.Error).ToNot(HaveOccurred())
+		Expect(id).ToNot(Equal(uint(0)))
 
 		payload, err := GetPayloadByRequestId(db(), requestId)
 		Expect(err).ToNot(HaveOccurred())
@@ -86,8 +87,9 @@ var _ = Describe("Queries", func() {
 			SystemId:    getUUID(),
 		}
 
-		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		result, id := UpsertPayloadByRequestId(db(), requestId, payload)
 		Expect(result.Error).ToNot(HaveOccurred())
+		Expect(id).ToNot(Equal(uint(0)))
 
 		payload, err := GetPayloadByRequestId(db(), requestId)
 		Expect(err).ToNot(HaveOccurred())
@@ -117,8 +119,9 @@ var _ = Describe("Queries", func() {
 			OrgId:     "5678",
 		}
 
-		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		result, id := UpsertPayloadByRequestId(db(), requestId, payload)
 		Expect(result.Error).ToNot(HaveOccurred())
+		Expect(id).ToNot(Equal(uint(0)))
 
 		payload, err := GetPayloadByRequestId(db(), requestId)
 		Expect(err).ToNot(HaveOccurred())
@@ -142,12 +145,13 @@ var _ = Describe("Queries", func() {
 		}
 		Expect(db().Create(&payload).Error).ToNot(HaveOccurred())
 
-		payload = models.Payloads{
+		newPayload := models.Payloads{
 			RequestId: requestId,
 		}
 
-		result, _ := UpsertPayloadByRequestId(db(), requestId, payload)
+		result, id := UpsertPayloadByRequestId(db(), requestId, newPayload)
 		Expect(result.Error).ToNot(HaveOccurred())
+		Expect(id).ToNot(Equal(uint(0)))
 
 		payload, err := GetPayloadByRequestId(db(), requestId)
 		Expect(err).ToNot(HaveOccurred())
@@ -157,5 +161,6 @@ var _ = Describe("Queries", func() {
 		Expect(payload.SystemId).To(Equal(systemId))
 		Expect(payload.Account).To(Equal("1234"))
 		Expect(payload.OrgId).To(Equal("1234"))
+		Expect(payload.Id).ToNot(Equal(0))
 	})
 })


### PR DESCRIPTION
Using `DO NOTHING` results in no record being returned, so the upsert returns an empty payload record with ID of 0.

I tried to use an empty update clause that would result in a statement similar to `DO UPDATE RETURNING "id"` but gorm translated an empty update array into this statement:
```
INSERT INTO "payloads" ("request_id","account","inventory_id","system_id","created_at","org_id") VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT ("request_id") DO UPDATE SET "id"="id" RETURNING "id"
```

I also tried using `DoNothing: true` with an explicit `clause.Returning{}` for the "id" column but that didn't work either.

So to get around this, we will always perform an UPDATE on conflict and always call a `SET` on the `request_id` field, even though this field is not going to change.