### PR TITLE
Remove seeder, this is handled in the IQE plugin now.

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -21,7 +21,6 @@ curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 source $CICD_ROOT/build.sh
 # source $APP_ROOT/unit_test.sh
 source $CICD_ROOT/deploy_ephemeral_env.sh
-oc rsh -n $NAMESPACE deployment/payload-tracker-api ./pt-seeder
 COMPONENT_NAME=payload-tracker
 source $CICD_ROOT/cji_smoke_test.sh
 source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
## What?
Removes the seeder as it wasn't compatible in it's current form in the Konflux pipelines

## Why?
^
## How?
We now do the seeding in the IQE plugin, this was only needed in ephemeral environments.

## Testing
Yes, the entire IQE suite