### PR TITLE
RHCLOUD-36895 | refactor: reduce logging noise

### DIFF
--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -100,10 +100,10 @@ func NewConsumerEventLoop(
 					break
 				}
 
-				l.Log.Debugf("Ignored OffsetsComitted: %#v", e)
+				l.Log.Tracef("Ignored OffsetsComitted: %#v", e)
 
 			default:
-				l.Log.Infof("Ignored %#v\n", e)
+				l.Log.Infof("Ignored Kafka event: %#v\n", e)
 			}
 
 		}

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -94,8 +94,16 @@ func NewConsumerEventLoop(
 			case kafka.Error:
 				endpoints.IncConsumeErrors()
 				l.Log.Errorf("Consumer error: %v (%v)\n", e.Code(), e)
+			case kafka.OffsetsCommitted:
+				if e.Error != nil {
+					l.Log.Errorf("Unable to commit offset: %#v", e)
+					break
+				}
+
+				l.Log.Debugf("Ignored OffsetsComitted: %#v", e)
+
 			default:
-				l.Log.Infof("Ignored %v\n", e)
+				l.Log.Infof("Ignored %#v\n", e)
 			}
 
 		}


### PR DESCRIPTION
## What?
Puts the "Ignored OffsetCommitted" error messages under the "debug" log level.

## Why?
The log messages about the ignored committed offsets are not really useful unless we are debugging problems with that. Therefore, we could simply leave an error log message for when the offset committing goes wrong, and a debug one when we really want to know that offsets are being committed.

## Jira ticket
[[RHCLOUD-36895]](https://issues.redhat.com/browse/RHCLOUD-36895)