### PR TITLE
RHCLOUD-36896 | refactor: increment errors counter when retries have been depleted

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/redhatinsights/payload-tracker-go/internal/queries"
 )
 
-
 type handler struct {
 	db *gorm.DB
 }
@@ -117,13 +116,13 @@ func (this *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *con
 	endpoints.IncMessagesProcessed()
 	result := queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
 	if result.Error != nil {
-		endpoints.IncMessageProcessErrors()
 		l.Log.Debug("Failed to insert sanitized PayloadStatus with ERROR: ", result.Error)
 		result = queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
 		if result.Error != nil {
 			l.Log.Debug("Failed to re-insert sanitized PayloadStatus with ERROR: ", result.Error)
 			result = queries.InsertPayloadStatus(this.db, sanitizedPayloadStatus)
 			if result.Error != nil {
+				endpoints.IncMessageProcessErrors()
 				l.Log.Error("Failed final attempt to re-insert PayloadStatus with ERROR: ", result.Error)
 			}
 		}


### PR DESCRIPTION
## What?
Increment the "processed errors" counter only when all the retries have been depleted.

## Why?
Right now if an error occurs when attempting to store the payload in the first attempt, the "processing errors" counter is incremented, even if that payload might be properly stored in a second attempt.

This might trigger alerts that actually do not really need any attention, since the payloads might be getting updated correctly.

## Jira ticket
[[RHCLOUD-36896]](https://issues.redhat.com/browse/RHCLOUD-36896)