### PR TITLE
RHCLOUD-36944 Bump Postgres to 16 in the DB cleanup job

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -120,7 +120,7 @@ objects:
       schedule: ${CLEANER_SCHEDULE}
       suspend: ${{CLEANER_SUSPEND}}
       podSpec:
-        image: quay.io/cloudservices/postgresql-rds:12
+        image: quay.io/cloudservices/postgresql-rds:16
         restartPolicy: Never
         volumes:
           - name: payload-tracker-go-db-cleaner-volume


### PR DESCRIPTION
## What?
[RHCLOUD-36944](https://issues.redhat.com/browse/RHCLOUD-36944)

This PR bumps the Postgres version used in the DB cleanup job from 12 to 16.

## Why?

All services need to bump Postgres to 16.

## How?

## Testing

Testing will consist in a cronjob execution in stage.

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
