### PR TITLE
RHCLOUD-40127 Add link to RDS dashboard in Payload Tracker dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-payload-tracker-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-payload-tracker-general.configmap.yaml
@@ -27,6 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
+      "id": 886179,
       "links": [
         {
           "icon": "external link",
@@ -75,6 +76,18 @@ data:
           "title": "Service Prod Deployment",
           "type": "link",
           "url": "https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns/payload-tracker-prod/deployments/payload-tracker/pods"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": true,
+          "title": "AWS RDS dashboard for Payload Tracker",
+          "tooltip": "",
+          "type": "link",
+          "url": "https://grafana.app-sre.devshift.net/d/AWSRDSdbi/aws-rds?var-datasource=PD4288CE6A02EB473&var-region=default&var-dbinstanceidentifier=payload-tracker-prod-db"
         }
       ],
       "liveNow": false,
@@ -1318,7 +1331,7 @@ data:
       "timezone": "",
       "title": "Payload Tracker",
       "uid": "eGSUe-SZk",
-      "version": 4,
+      "version": 5,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## What?
[RHCLOUD-40127](https://issues.redhat.com/browse/RHCLOUD-40127)
This PR adds a link to the AWS RDS dashboard maintained by App SRE to the Payload Tracker dashboard.

## Why?
This is better than adding the graphs about the DB into the Export Service dashboard directly because we won't have to maintain the graphs with the approach from this PR.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
