### PR TITLE
[RHCLOUD-40988] Replace Postgres image for DB cleaner

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -120,7 +120,7 @@ objects:
       schedule: ${CLEANER_SCHEDULE}
       suspend: ${{CLEANER_SUSPEND}}
       podSpec:
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/postgresql-rds:16
+        image: registry.redhat.io/rhel9/postgresql-16:latest
         restartPolicy: Never
         volumes:
           - name: payload-tracker-go-db-cleaner-volume


### PR DESCRIPTION
## What?

- https://issues.redhat.com/browse/RHCLOUD-40988
- https://issues.redhat.com/browse/RHCLOUD-41106

## Why?

Migrate to an internally supported build of Postgres for maintenance purposes

## How?

Switching to the [rhel9/postgresql-16 image](https://catalog.redhat.com/software/containers/rhel9/postgresql-16/657b03866783e1b1fb87e142) natively available within OpenShift.

## Testing

Must be tested within remote environment.

## Anything Else?

Slack threads:
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1753203060467389
- https://redhat-internal.slack.com/archives/C024CDDPRHD/p1753194314900779

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
