### PR TITLE
Update vacuum imagePullPolicy to Always

### DIFF
--- a/deployments/clowdapp.yml
+++ b/deployments/clowdapp.yml
@@ -121,6 +121,7 @@ objects:
       suspend: ${{CLEANER_SUSPEND}}
       podSpec:
         image: registry.redhat.io/rhel9/postgresql-16:latest
+        imagePullPolicy: Always
         restartPolicy: Never
         volumes:
           - name: payload-tracker-go-db-cleaner-volume


### PR DESCRIPTION
## What?
Updating vacuum imagePullPolicy to always pull latest image. 

## Why?
Currently the imagePullPolicy is set to ifNotPresent. This caches the image "As latest will always be present" thereby not actually pulling the latest image whenever the cronjob is run. This keeps the image stale and vulnerable, especially to RPM CVE's.

## How?
Set imagePullPolicy to Always.

## Testing
Did you add any tests for the change?

## Anything Else?
NA

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
