### PR TITLE
fix(kafka): add message processing failure counter

### DIFF
--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -39,6 +39,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 		} else {
 			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)
 		}
+		endpoints.IncMessageProcessErrors()
 		return
 	}
 
@@ -55,6 +56,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 	upsertResult, payloadId := queries.UpsertPayloadByRequestId(h.db, payloadStatus.RequestID, payload)
 	if upsertResult.Error != nil {
 		l.Log.Error("ERROR Payload table upsert failed: ", upsertResult.Error)
+		endpoints.IncMessageProcessErrors()
 		return
 	}
 	sanitizedPayloadStatus.PayloadId = payloadId
@@ -71,6 +73,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 		statusResult, newStatus := queries.CreateStatusTableEntry(h.db, payloadStatus.Status)
 		if statusResult.Error != nil {
 			l.Log.Error("Error Creating Statuses Table Entry ERROR: ", statusResult.Error)
+			endpoints.IncMessageProcessErrors()
 			return
 		}
 
@@ -83,6 +86,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 		serviceResult, newService := queries.CreateServiceTableEntry(h.db, payloadStatus.Service)
 		if serviceResult.Error != nil {
 			l.Log.Error("Error Creating Service Table Entry ERROR: ", serviceResult.Error)
+			endpoints.IncMessageProcessErrors()
 			return
 		}
 
@@ -99,6 +103,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 			result, newSource := queries.CreateSourceTableEntry(h.db, payloadStatus.Source)
 			if result.Error != nil {
 				l.Log.Error("Error Creating Sources Table Entry ERROR: ", result.Error)
+				endpoints.IncMessageProcessErrors()
 				return
 			}
 
@@ -129,6 +134,11 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 
 		l.Log.WithFields(logrus.Fields{"attempts": attempts}).Debug("Failed to insert sanitized PayloadStatus with ERROR: ", err)
 		attempts += 1
+	}
+
+	if attempts >= retries && retries > 0 {
+		l.Log.Error("ERROR: All retries exhausted for PayloadStatus insert")
+		endpoints.IncMessageProcessErrors()
 	}
 }
 

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -39,12 +39,12 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 		} else {
 			l.Log.Error("ERROR: Unmarshaling Payload Status Event: ", err)
 		}
-		endpoints.IncMessageProcessErrors()
+		endpoints.IncInvalidConsumerRequestIDs()
 		return
 	}
 
 	if !validateRequestID(cfg.RequestConfig.ValidateRequestIDLength, payloadStatus.RequestID) {
-		endpoints.IncMessageProcessErrors()
+		endpoints.IncInvalidConsumerRequestIDs()
 		return
 	}
 
@@ -146,7 +146,6 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 func validateRequestID(requestIDLength int, requestID string) bool {
 	if requestIDLength != 0 {
 		if len(requestID) != requestIDLength {
-			endpoints.IncInvalidConsumerRequestIDs()
 			return false
 		}
 	}

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -44,6 +44,7 @@ func (h *handler) onMessage(ctx context.Context, msg *kafka.Message, cfg *config
 	}
 
 	if !validateRequestID(cfg.RequestConfig.ValidateRequestIDLength, payloadStatus.RequestID) {
+		endpoints.IncMessageProcessErrors()
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Wire up the existing `payload_tracker_message_process_errors` Prometheus counter (`IncMessageProcessErrors()`) at every failure return path in the Kafka message handler
- Covers: JSON unmarshal errors, payload upsert failures, status/service/source table entry creation errors, and DB insert retry exhaustion
- The counter and helper function already existed in `internal/endpoints/metrics.go` but were never called

RHCLOUD-45237

## Test plan
- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Verify `go vet ./...` shows no new warnings (confirmed — existing warnings are pre-existing)
- [ ] CI tests pass (requires DB — runs in CI)
- [ ] Confirm `payload_tracker_message_process_errors` metric increments on message processing failures in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)