### PR TITLE
Enable hermetic builds with hummingbird FIPS images (RHCLOUD-48958)

### DIFF
--- a/.tekton/payload-tracker-go-pull-request.yaml
+++ b/.tekton/payload-tracker-go-pull-request.yaml
@@ -29,6 +29,14 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: prefetch-dev-package-managers
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/payload-tracker-go-push.yaml
+++ b/.tekton/payload-tracker-go-push.yaml
@@ -26,6 +26,14 @@ spec:
     value: quay.io/redhat-user-workloads/hcc-integrations-tenant/payload-tracker/payload-tracker-go:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: prefetch-dev-package-managers
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/payload-tracker-go-sc-pull-request.yaml
+++ b/.tekton/payload-tracker-go-sc-pull-request.yaml
@@ -29,6 +29,14 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: prefetch-dev-package-managers
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/payload-tracker-go-sc-push.yaml
+++ b/.tekton/payload-tracker-go-sc-push.yaml
@@ -26,6 +26,14 @@ spec:
     value: quay.io/redhat-user-workloads/hcc-integrations-tenant/payload-tracker-go-sc/payload-tracker-sc:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: prefetch-dev-package-managers
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,35 +1,39 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+################################
+# STEP 1 build executable binaries
+################################
+FROM registry.access.redhat.com/hi/go:latest-fips-builder AS builder
 
-WORKDIR /go/src/app
+USER 0
+
+WORKDIR /workspace
+
+# Cache deps before copying source so that we do not need to re-download for every build
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY api api
 COPY cmd cmd
 COPY internal internal
 COPY tools tools
-COPY go.mod go.mod
-COPY go.sum go.sum
 COPY migrations migrations
 
-ARG GOTOOLCHAIN=go1.26.4+auto
+RUN go build -ldflags "-w -s" -o pt-api cmd/payload-tracker-api/main.go && \
+    go build -ldflags "-w -s" -o pt-consumer cmd/payload-tracker-consumer/main.go && \
+    go build -ldflags "-w -s" -o pt-migration internal/migration/main.go && \
+    go build -ldflags "-w -s" -o pt-seeder tools/db-seeder/main.go
 
-USER 0
-
-RUN go build -o pt-api cmd/payload-tracker-api/main.go && \
-    go build -o pt-consumer cmd/payload-tracker-consumer/main.go && \
-    go build -o pt-migration internal/migration/main.go && \
-    go build -o pt-seeder tools/db-seeder/main.go
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-
-USER 0
+############################
+# STEP 2 build a small image
+############################
+FROM registry.access.redhat.com/hi/go:latest-fips
 
 WORKDIR /
 
-COPY --from=builder /go/src/app/pt-api ./pt-api
-COPY --from=builder /go/src/app/pt-consumer ./pt-consumer
-COPY --from=builder /go/src/app/pt-migration ./pt-migration
-COPY --from=builder /go/src/app/migrations /migrations/
-COPY --from=builder /go/src/app/pt-seeder ./pt-seeder
+COPY --from=builder /workspace/pt-api ./pt-api
+COPY --from=builder /workspace/pt-consumer ./pt-consumer
+COPY --from=builder /workspace/pt-migration ./pt-migration
+COPY --from=builder /workspace/migrations /migrations/
+COPY --from=builder /workspace/pt-seeder ./pt-seeder
 COPY tools ./tools
 
 USER 1001


### PR DESCRIPTION
## What
Enable hermetic builds for Payload Tracker using hummingbird FIPS-compliant base images.

## Why
RHCLOUD-48958 — required for hermetic build compliance.

## How
- Switch Dockerfile from `ubi9/go-toolset` / `ubi9/ubi-minimal` to `hi/go:latest-fips-builder` / `hi/go:latest-fips`
- Add hermetic build params to all 4 Tekton pipelines (`hermetic`, `prefetch-input`, `build-source-image`, `prefetch-dev-package-managers`)
- Add `go mod download` layer caching for faster rebuilds
- Strip debug symbols with `-ldflags "-w -s"` (matching ingress-go pattern)

## Testing
- Built x86-64 image locally with podman
- Verified all 4 binaries (`pt-api`, `pt-consumer`, `pt-migration`, `pt-seeder`) execute inside container
- `pt-migration` shows help output; other 3 fail at DB connect as expected (no postgres available)